### PR TITLE
Address PR review feedback for NSD role

### DIFF
--- a/ansible/inventories/group_vars/dns_servers.yml
+++ b/ansible/inventories/group_vars/dns_servers.yml
@@ -26,9 +26,7 @@ managed_users:
 # NSD configuration
 nsd_zones:
   - name: lan.quietlife.net
-    type: primary
   - name: 15.10.10.in-addr.arpa
-    type: primary
 
 # Zone parameters
 nsd_default_ttl: 300
@@ -36,3 +34,6 @@ nsd_soa_refresh: 3600
 nsd_soa_retry: 600
 nsd_soa_expire: 604800
 nsd_soa_minimum: 300
+
+# Zone serial - use YYYYMMDDNN format, increment NN when making changes
+nsd_zone_serial: 2025120501

--- a/ansible/roles/nsd/tasks/main.yml
+++ b/ansible/roles/nsd/tasks/main.yml
@@ -39,6 +39,7 @@
     owner: root
     group: nsd
     mode: "0644"
+    validate: "nsd-checkzone lan.quietlife.net %s"
   notify: Reload NSD
 
 - name: Create reverse zone file
@@ -48,6 +49,7 @@
     owner: root
     group: nsd
     mode: "0644"
+    validate: "nsd-checkzone 15.10.10.in-addr.arpa %s"
   notify: Reload NSD
 
 - name: Check if NSD is installed

--- a/ansible/roles/nsd/templates/15.10.10.in-addr.arpa.zone.j2
+++ b/ansible/roles/nsd/templates/15.10.10.in-addr.arpa.zone.j2
@@ -5,7 +5,7 @@ $ORIGIN 15.10.10.in-addr.arpa.
 $TTL {{ nsd_default_ttl }}
 
 @       IN      SOA     {{ nsd_primary_ns }}. {{ nsd_hostmaster }}. (
-                        {{ ansible_date_time.epoch }}  ; serial (epoch timestamp)
+                        {{ nsd_zone_serial }}  ; serial (YYYYMMDDNN)
                         {{ nsd_soa_refresh }}          ; refresh
                         {{ nsd_soa_retry }}            ; retry
                         {{ nsd_soa_expire }}           ; expire

--- a/ansible/roles/nsd/templates/lan.quietlife.net.zone.j2
+++ b/ansible/roles/nsd/templates/lan.quietlife.net.zone.j2
@@ -5,7 +5,7 @@ $ORIGIN lan.quietlife.net.
 $TTL {{ nsd_default_ttl }}
 
 @       IN      SOA     {{ nsd_primary_ns }}. {{ nsd_hostmaster }}. (
-                        {{ ansible_date_time.epoch }}  ; serial (epoch timestamp)
+                        {{ nsd_zone_serial }}  ; serial (YYYYMMDDNN)
                         {{ nsd_soa_refresh }}          ; refresh
                         {{ nsd_soa_retry }}            ; retry
                         {{ nsd_soa_expire }}           ; expire


### PR DESCRIPTION
## Summary

This PR addresses the three actionable review comments from GitHub Copilot on the original NSD implementation (PR #36):

- **Zone serial format**: Changed from epoch-based to YYYYMMDDNN format with configurable `nsd_zone_serial` variable
- **Zone file validation**: Added `nsd-checkzone` validation to zone template tasks to catch syntax errors before deployment
- **Removed unused field**: Removed `type: primary` from zone configuration (not used in our setup)

## Changes

- `ansible/inventories/group_vars/dns_servers.yml`: Added `nsd_zone_serial` variable, removed unused `type` fields
- `ansible/roles/nsd/tasks/main.yml`: Added `validate` parameter to zone file template tasks
- `ansible/roles/nsd/templates/*.zone.j2`: Updated to use `{{ nsd_zone_serial }}` variable

## Test Plan

- [ ] Run `make ansible-dns` to apply changes to dns1
- [ ] Verify zone files are validated during deployment
- [ ] Confirm NSD reloads successfully with new serial format
- [ ] Test DNS queries still work correctly

Related: PR #36