### PR TITLE
Add NFS media mount for Jellyfin

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -27,8 +27,7 @@ services:
     volumes:
       - jellyfin_config:/config
       - jellyfin_cache:/cache
-      # TODO: Add NFS media mount
-      # - /mnt/media:/media:ro
+      - /mnt/media:/media:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.lan.quietlife.net`)"

--- a/ansible/inventories/group_vars/container_hosts.yml
+++ b/ansible/inventories/group_vars/container_hosts.yml
@@ -29,3 +29,10 @@ managed_users:
 docker_users:
   - deploy
   - cwage
+
+# NFS mounts for media access
+nfs_mounts:
+  - name: media
+    src: 10.10.15.4:/volume1/Video
+    path: /mnt/media
+    opts: "ro,_netdev,hard,vers=3,noatime"

--- a/ansible/playbooks/containers.yml
+++ b/ansible/playbooks/containers.yml
@@ -7,6 +7,7 @@
     - hostname
     - users
     - packages
+    - nfs_mounts
     - docker_host
 
   tasks:


### PR DESCRIPTION
## Summary
- Add NFS mount for Video share from NAS (10.10.15.4:/volume1/Video)
- Mount read-only at /mnt/media on containers VM
- Bind mount into Jellyfin container at /media
- Add nfs_mounts role to containers playbook

## Test plan
- [x] Verified NFS mount accessible on VM
- [x] Verified Jellyfin can see media directories (Movies, Television, etc.)
- [x] Completed Jellyfin initial setup and added libraries
