### PR TITLE
Add NFS music mount for Jellyfin

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - jellyfin_config:/config
       - jellyfin_cache:/cache
       - /mnt/media:/media:ro
+      - /mnt/music:/music:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.lan.quietlife.net`)"

--- a/ansible/inventories/group_vars/container_hosts.yml
+++ b/ansible/inventories/group_vars/container_hosts.yml
@@ -39,3 +39,7 @@ nfs_mounts:
     src: 10.10.15.4:/volume1/Video
     path: /mnt/media
     opts: "ro,_netdev,hard,vers=3,noatime"
+  - name: music
+    src: 10.10.15.4:/volume1/Music
+    path: /mnt/music
+    opts: "ro,_netdev,hard,vers=3,noatime"


### PR DESCRIPTION
## Summary
Add Music NFS share mount for Jellyfin music library support.

## Changes
- Add `/mnt/music` NFS mount (10.10.15.4:/volume1/Music) to container_hosts
- Mount `/mnt/music` into Jellyfin container at `/music`

## Test plan
- [x] NFS mount created and mounted
- [x] Jellyfin container recreated with new volume
- [ ] Add music library in Jellyfin UI pointing to `/music`