### PR TITLE
Enable TLS verification for Proxmox provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,8 @@ BAO_TOKEN=
 # Proxmox API Configuration (for OpenTofu VM provisioning)
 # =============================================================================
 
-# Proxmox API URL
-PM_API_URL=https://10.10.15.18:8006/api2/json
+# Proxmox API URL (use hostname for TLS verification with wildcard cert)
+PM_API_URL=https://pve1.lan.quietlife.net:8006/api2/json
 
 # Proxmox API Token ID (format: user@realm!tokenid)
 # Example: root@pam!tofu-token

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -10,7 +10,7 @@ terraform {
 provider "proxmox" {
   endpoint  = var.pm_api_url
   api_token = "${var.pm_api_token_id}=${var.pm_api_token_secret}"
-  insecure  = true # Set to false in production with valid certs
+  insecure  = false # Wildcard cert deployed via ansible proxmox_certs role
 
   ssh {
     agent = true


### PR DESCRIPTION
Now that the wildcard certificate is deployed to Proxmox via the `proxmox_certs` role, we can enable TLS verification in the OpenTofu provider.

## Changes
- Set `insecure = false` in Proxmox provider config

## Test plan
- [x] Run `make tofu-plan` to verify provider can connect with TLS verification