### PR TITLE
Disable temporal storms for vs-buttopia

### DIFF
--- a/ansible/inventories/group_vars/gaming_servers.yml
+++ b/ansible/inventories/group_vars/gaming_servers.yml
@@ -46,6 +46,8 @@ gaming_profiles:
       creatureSwimSpeed: 2
       daysPerMonth: 9
       harshWinters: true
+      temporalStability: false
+      temporalStorms: "off"
   - name: vs-sloths
     game: vintagestory
     active: false


### PR DESCRIPTION
Disable temporal storms and stability mechanics for vs-buttopia to make early game less punishing.

## Changes
- Set `temporalStability: false` - disables stability drain mechanic
- Set `temporalStorms: "off"` - no more temporal storms

## Notes
- Applied to existing world via `/worldconfig` commands
- New worlds will have these settings baked in from serverconfig.json
