### PR TITLE
Add Cloudflare Tunnel for external Jellyfin access

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -61,7 +61,7 @@ services:
               capabilities: [gpu]
 
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    image: cloudflare/cloudflared:2026.1.2
     container_name: cloudflared
     restart: unless-stopped
     command: tunnel run
@@ -71,6 +71,8 @@ services:
       - proxy
     depends_on:
       - jellyfin
+    profiles:
+      - tunnel
 
 networks:
   proxy:

--- a/ansible/playbooks/containers.yml
+++ b/ansible/playbooks/containers.yml
@@ -103,18 +103,22 @@
           ansible.builtin.debug:
             msg: >
               Cloudflare Tunnel token not found in OpenBao at kv/infra/cloudflare/tunnel.
-              Cloudflared container will not start until token is configured.
+              Cloudflared container will be skipped (tunnel profile disabled).
               Store token with: bao kv put kv/infra/cloudflare/tunnel token=<YOUR_TOKEN>
         - name: Set empty tunnel token
           ansible.builtin.set_fact:
             cloudflare_tunnel:
               token: ""
 
+    - name: Determine if tunnel should be enabled
+      ansible.builtin.set_fact:
+        tunnel_enabled: "{{ (cloudflare_tunnel.token | default('')) | length > 0 }}"
+
     - name: Deploy stacks environment file
       ansible.builtin.copy:
         content: |
           # Managed by Ansible - do not edit manually
-          CLOUDFLARE_TUNNEL_TOKEN={{ cloudflare_tunnel.token }}
+          CLOUDFLARE_TUNNEL_TOKEN={{ cloudflare_tunnel.token | default('') }}
         dest: /opt/stacks/.env
         owner: deploy
         group: deploy
@@ -143,7 +147,7 @@
 
     - name: Start containers
       ansible.builtin.command:
-        cmd: docker compose up -d
+        cmd: "docker compose {{ '--profile tunnel' if tunnel_enabled else '' }} up -d"
         chdir: /opt/stacks
       become_user: deploy
       when: containers_need_restart


### PR DESCRIPTION
Add Cloudflare Tunnel for secure external Jellyfin access

## Summary
- Adds `cloudflared` container to docker-compose stack
- Retrieves tunnel token from OpenBao at `kv/infra/cloudflare/tunnel`
- Deploys token to `/opt/stacks/.env` with restricted permissions (0600)
- Gracefully handles missing token (warns but doesn't fail deployment)

## Setup required
1. Create tunnel in Cloudflare Zero Trust dashboard (Networks → Connectors)
2. Store token: `bao kv put kv/infra/cloudflare/tunnel token=<TOKEN>`
3. Configure public hostname in Cloudflare dashboard pointing to `jellyfin:8096`

## Test plan
- [x] Deployed to containers VM
- [x] Tunnel connected to Cloudflare
- [x] External access verified at `https://jellyfin.quietlife.net/`
