### PR TITLE
Consolidate NAS mounts and switch Jellyfin to LinuxServer image

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - proxy
 
   jellyfin:
-    image: jellyfin/jellyfin:10.11.4
+    image: linuxserver/jellyfin:10.11.6
     container_name: jellyfin
     restart: unless-stopped
     environment:
@@ -42,8 +42,7 @@ services:
     volumes:
       - jellyfin_config:/config
       - jellyfin_cache:/cache
-      - /mnt/media:/media:ro
-      - /mnt/music:/music:ro
+      - /mnt/media:/media
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.lan.quietlife.net`)"

--- a/ansible/inventories/group_vars/container_hosts.yml
+++ b/ansible/inventories/group_vars/container_hosts.yml
@@ -20,10 +20,6 @@ nvidia_container_enabled: true
 # NFS mounts for media access
 nfs_mounts:
   - name: media
-    src: 10.10.15.4:/volume1/Video
+    src: 10.10.15.4:/volume1/Media
     path: /mnt/media
-    opts: "ro,_netdev,hard,vers=3,noatime"
-  - name: music
-    src: 10.10.15.4:/volume1/Music
-    path: /mnt/music
-    opts: "ro,_netdev,hard,vers=3,noatime"
+    opts: "rw,_netdev,hard,vers=3,noatime"


### PR DESCRIPTION
## Summary
Consolidates the separate Video and Music NFS mounts into a single Media share and switches Jellyfin to the LinuxServer image for consistent user permissions.

## Changes
- Replace two read-only NFS mounts (`/volume1/Video`, `/volume1/Music`) with single read-write mount (`/volume1/Media`)
- Switch from `jellyfin/jellyfin:10.11.4` to `linuxserver/jellyfin:10.11.6`
- LinuxServer image properly honors PUID/PGID environment variables

## Why
- Prepares for arr stack (Radarr/Sonarr/SABnzbd) which needs write access to media directories
- Single mount enables atomic moves (instant rename vs copy) for downloads
- Consistent PUID=1000/PGID=1000 across all media containers matches NAS file ownership

## Test Plan
- [x] NFS mount working with rw access
- [x] Jellyfin container starts with LinuxServer image
- [x] Library paths updated (`/media/Movies`, `/media/Television`, `/media/Music`)
- [x] Library scan running successfully

Part of #101
