### PR TITLE
Add Dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # OpenTofu provider updates
+  - package-ecosystem: "terraform"
+    directory: "/tofu"
+    schedule:
+      interval: "weekly"
+
+  # Container images in production stack
+  - package-ecosystem: "docker"
+    directory: "/ansible/files/stacks"
+    schedule:
+      interval: "weekly"
+
+  # Development/build Dockerfiles
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "docker"
+    directory: "/tofu"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "docker"
+    directory: "/ansible"
+    schedule:
+      interval: "monthly"
+
+  # Lego ACME client
+  - package-ecosystem: "docker"
+    directory: "/lego"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add Dependabot configuration to automate dependency update monitoring.

## Changes
- Add `.github/dependabot.yml` with update schedules for:
  - **OpenTofu providers** (`/tofu`) - weekly checks
  - **Production container images** (`/ansible/files/stacks`) - weekly checks
  - **Development Dockerfiles** (`/`, `/tofu`, `/ansible`) - monthly checks
  - **Lego ACME client** (`/lego`) - weekly checks

## Limitations
Dependabot cannot monitor:
- Debian/OS packages in Ansible playbooks or apt installs
- Ansible Galaxy collections (no native ecosystem)

For OS-level security patching, consider unattended-upgrades on hosts or container scanning tools like Trivy.

## Test Plan
- Merge and verify Dependabot starts creating PRs for available updates
- Note: `lego/docker-compose.yml` uses `latest` tag - consider pinning for meaningful tracking
