### PR TITLE
Fix Dependabot config: remove compose-only directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,9 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Container images in production stack
-  - package-ecosystem: "docker"
-    directory: "/ansible/files/stacks"
-    schedule:
-      interval: "weekly"
-
   # Development/build Dockerfiles
+  # Note: Dependabot's docker ecosystem only works with Dockerfile files,
+  # not docker-compose.yml. Directories with only compose files are excluded.
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -27,9 +23,3 @@ updates:
     directory: "/ansible"
     schedule:
       interval: "monthly"
-
-  # Lego ACME client
-  - package-ecosystem: "docker"
-    directory: "/lego"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Fix Dependabot configuration to only include directories with Dockerfiles.

## Changes
- Remove `/ansible/files/stacks` directory (only has `docker-compose.yml`)
- Remove `/lego` directory (only has `docker-compose.yml`)
- Add comment explaining the limitation

## Context
Dependabot's `docker` ecosystem only scans `Dockerfile` files for base image updates. It does not parse `docker-compose.yml` files for image references. The removed directories were failing with:

```
No Dockerfiles nor Kubernetes YAML found in /ansible/files/stacks
No Dockerfiles nor Kubernetes YAML found in /lego
```

## Test Plan
- Merge and verify Dependabot scans succeed for remaining directories
- Consider Renovate or manual tracking for compose file image updates
