### PR TITLE
Fix backup container env var handling

### DIFF
--- a/backup/docker-compose.yml
+++ b/backup/docker-compose.yml
@@ -9,18 +9,6 @@ services:
         required: false
       - path: .env
         required: false
-    environment:
-      - BAO_ADDR=${BAO_ADDR:-}
-      - BAO_TOKEN=${BAO_TOKEN:-}
-      - BAO_SKIP_VERIFY=${BAO_SKIP_VERIFY:-}
-      # rclone env vars can be set in .env as fallback
-      - RCLONE_CONFIG_B2_TYPE=${RCLONE_CONFIG_B2_TYPE:-}
-      - RCLONE_CONFIG_B2_ACCOUNT=${RCLONE_CONFIG_B2_ACCOUNT:-}
-      - RCLONE_CONFIG_B2_KEY=${RCLONE_CONFIG_B2_KEY:-}
-      - RCLONE_CONFIG_B2CRYPT_TYPE=${RCLONE_CONFIG_B2CRYPT_TYPE:-}
-      - RCLONE_CONFIG_B2CRYPT_REMOTE=${RCLONE_CONFIG_B2CRYPT_REMOTE:-}
-      - RCLONE_CONFIG_B2CRYPT_PASSWORD=${RCLONE_CONFIG_B2CRYPT_PASSWORD:-}
-      - RCLONE_CONFIG_B2CRYPT_PASSWORD2=${RCLONE_CONFIG_B2CRYPT_PASSWORD2:-}
     volumes:
       # NAS shares (read-only for backup)
       - /mnt/nas:/mnt/nas:ro


### PR DESCRIPTION
## Summary

- Remove explicit `environment` section from backup docker-compose.yml that was overriding `env_file` values with empty strings
- Docker Compose resolves `${VAR:-}` in the `environment` section from the host shell, not from `env_file` entries, so BAO/rclone credentials were silently being set to empty
- The `env_file` directive (loading `../.env` and `.env`) is sufficient on its own

## Testing

Verified `make backup-shell CMD='rclone lsd b2crypt:'` successfully fetches OpenBao credentials and lists B2 bucket contents after fix.

## Related

- #113