### PR TITLE
Add resume preview testing container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,18 @@ ANSIBLE_DIR := ansible
 TOFU_DIR := tofu
 LEGO_DIR := lego
 BACKUP_DIR := backup
+TESTING_DIR := testing
 
-ANSIBLE_TARGETS := help init build galaxy version ping access_check proxmox proxmox-check firewall firewall-check felix felix-check backup-deploy backup-deploy-check all check-all run adhoc sh build-tinyfugue trufflehog
+ANSIBLE_TARGETS := help init build galaxy version ping access_check proxmox proxmox-check firewall firewall-check felix felix-check backup-deploy backup-deploy-check testing-deploy testing-deploy-check testing-refresh testing-switch all check-all run adhoc sh build-tinyfugue trufflehog
 TOFU_TARGETS := help build shell init plan apply destroy fmt validate trufflehog clean
 LEGO_TARGETS := help run renew renew-staging renew-force list show fetch-creds store retrieve
 BACKUP_TARGETS := help build shell clean
+TESTING_TARGETS := help build clean
 TRUFFLEHOG_ARGS ?= filesystem /repo --fail --no-update --exclude-paths /repo/.trufflehog-exclude.txt
 
 .DEFAULT_GOAL := help
 
-.PHONY: help ansible tofu lego backup ansible-% tofu-% lego-% backup-% trufflehog install-precommit-hook
+.PHONY: help ansible tofu lego backup testing ansible-% tofu-% lego-% backup-% testing-% trufflehog install-precommit-hook
 
 help:
 	@echo "homelab monorepo"
@@ -23,6 +25,7 @@ help:
 	@echo "  make tofu-<target>      (targets: $(TOFU_TARGETS))"
 	@echo "  make lego-<target>      (targets: $(LEGO_TARGETS))"
 	@echo "  make backup-<target>    (targets: $(BACKUP_TARGETS))"
+	@echo "  make testing-<target>   (targets: $(TESTING_TARGETS))"
 	@echo "  make trufflehog         (root) scan entire repo for secrets"
 	@echo ""
 	@echo "Shortcuts:"
@@ -30,6 +33,7 @@ help:
 	@echo "  make tofu               # same as: (cd tofu && make)     -> opens component help/defaults"
 	@echo "  make lego               # same as: (cd lego && make)     -> opens component help/defaults"
 	@echo "  make backup             # same as: (cd backup && make)   -> opens component help/defaults"
+	@echo "  make testing            # same as: (cd testing && make)  -> opens component help/defaults"
 	@echo "  make install-precommit-hook # install root pre-commit hook (trufflehog)"
 
 ansible-%:
@@ -55,6 +59,12 @@ backup-%:
 
 backup:
 	@$(MAKE) -C $(BACKUP_DIR)
+
+testing-%:
+	@$(MAKE) -C $(TESTING_DIR) $*
+
+testing:
+	@$(MAKE) -C $(TESTING_DIR)
 
 trufflehog:
 	docker compose -f docker-compose.trufflehog.yml run --rm trufflehog $(TRUFFLEHOG_ARGS)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Homelab infrastructure repo. Components:
 - `ansible/` — host configuration management
 - `tofu/` — VM provisioning with OpenTofu/Terraform
+- `testing/` — testing/preview containers (e.g., resume preview via Jekyll)
 - `docs/` — shared design notes (e.g., `dns-plan.md`)
 
 ## Make targets
@@ -94,6 +95,20 @@ To restore later:
 1. Set `active: true` in group_vars
 2. Run `make ansible-gaming PROFILE=<name>`
 3. Extract the tarball to restore world data
+
+### Resume preview (testing container)
+
+Preview a resume branch at `preview.quietlife.net` before merging to master/GitHub Pages.
+
+| Command | Description |
+|---------|-------------|
+| `make ansible-testing-deploy` | Full deploy (copy files, build, start container) |
+| `make ansible-testing-deploy-check` | Dry-run deploy |
+| `make ansible-testing-refresh` | Restart container (pulls latest from current branch) |
+| `make ansible-testing-switch BRANCH=master` | Switch to a different branch and restart |
+| `make testing-build` | Build the Docker image locally |
+
+Day-to-day workflow: edit resume locally, `git push`, then `make ansible-testing-refresh` to see changes at `preview.quietlife.net`.
 
 ### Secrets and local state
 - OpenTofu API creds live in `tofu/.env` (gitignored).

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 DC := docker compose --env-file ../.env
 TRUFFLEHOG_ARGS ?= filesystem /work --fail --no-update --exclude-paths /work/.trufflehog-exclude.txt
 
-.PHONY: help init build galaxy version ping access_check proxmox proxmox-check firewall firewall-check felix felix-check nas nas-check nas-discover dns dns-check containers containers-check openbao openbao-check openbao-test gaming gaming-check gaming-configs gaming-archive backup-deploy backup-deploy-check all check-all run adhoc sh build-tinyfugue trufflehog
+.PHONY: help init build galaxy version ping access_check proxmox proxmox-check firewall firewall-check felix felix-check nas nas-check nas-discover dns dns-check containers containers-check openbao openbao-check openbao-test gaming gaming-check gaming-configs gaming-archive backup-deploy backup-deploy-check testing-deploy testing-deploy-check testing-refresh testing-switch all check-all run adhoc sh build-tinyfugue trufflehog
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | sed 's/:.*## /\t- /' | sed 's/^/make /'
@@ -99,6 +99,19 @@ backup-deploy: ## Deploy backup tooling to containers host (builds image, writes
 
 backup-deploy-check: ## Dry-run backup deployment with --check/--diff
 	$(DC) run --rm ansible ansible-playbook playbooks/backup-deploy.yml -vv --check --diff $(OPTS)
+
+testing-deploy: ## Deploy resume preview container to containers host [OPTS="-e resume_branch=master"]
+	$(DC) run --rm ansible ansible-playbook playbooks/testing-deploy.yml -vv $(OPTS)
+
+testing-deploy-check: ## Dry-run testing deployment with --check/--diff
+	$(DC) run --rm ansible ansible-playbook playbooks/testing-deploy.yml -vv --check --diff $(OPTS)
+
+testing-refresh: ## Restart testing container (pulls latest code from GitHub)
+	$(DC) run --rm ansible ansible-playbook playbooks/testing-refresh.yml -vv $(OPTS)
+
+testing-switch: ## Switch testing branch and restart [BRANCH=branch-name]
+	@if [ -z "$(BRANCH)" ]; then echo "BRANCH required. Example: make testing-switch BRANCH=master"; exit 1; fi
+	$(DC) run --rm ansible ansible-playbook playbooks/testing-refresh.yml -vv -e resume_branch=$(BRANCH) $(OPTS)
 
 all: ## Run standard playbooks (proxmox, firewall, felix)
 	$(MAKE) proxmox

--- a/ansible/docker-compose.yml
+++ b/ansible/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - ./:/work:Z
       - ../backup:/work-backup:ro,Z
+      - ../testing:/work-testing:ro,Z
     environment:
       - ANSIBLE_CONFIG=/work/ansible.cfg
       - HOME=/work

--- a/ansible/files/testing/docker-compose.yml
+++ b/ansible/files/testing/docker-compose.yml
@@ -1,0 +1,30 @@
+# Resume preview container for testing branches before merging
+# Deployed by: make ansible-testing-deploy
+# Managed by Ansible - do not edit manually on the host
+services:
+  resume-testing:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: resume-testing
+    restart: unless-stopped
+    env_file:
+      - .env
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.preview.rule=Host(`preview.lan.quietlife.net`)"
+      - "traefik.http.routers.preview.entrypoints=websecure"
+      - "traefik.http.routers.preview.tls=true"
+      - "traefik.http.services.preview.loadbalancer.server.port=4000"
+    volumes:
+      - resume_testing_site:/site
+      - ./deploy_key:/run/secrets/deploy_key:ro
+    networks:
+      - proxy
+
+volumes:
+  resume_testing_site:
+
+networks:
+  proxy:
+    external: true

--- a/ansible/inventories/group_vars/dns_servers.yml
+++ b/ansible/inventories/group_vars/dns_servers.yml
@@ -20,4 +20,4 @@ nsd_soa_expire: 604800
 nsd_soa_minimum: 300
 
 # Zone serial - use YYYYMMDDNN format, increment NN when making changes
-nsd_zone_serial: 2026020701
+nsd_zone_serial: 2026021101

--- a/ansible/playbooks/testing-deploy.yml
+++ b/ansible/playbooks/testing-deploy.yml
@@ -1,0 +1,117 @@
+---
+# Deploy resume preview container to the containers host
+# Clones the resume repo from GitHub and serves Jekyll on port 4000.
+# Cloudflared routes preview.quietlife.net to this container.
+#
+# Usage: make ansible-testing-deploy
+#
+# Override branch: make ansible-testing-deploy OPTS="-e resume_branch=master"
+
+- name: Deploy resume testing container
+  hosts: container_hosts
+  become: true
+  gather_facts: false
+
+  vars:
+    resume_branch: "add-github-experience-multiline-yaml"
+
+  tasks:
+    # Fetch deploy key from OpenBao
+    - name: Retrieve deploy key from OpenBao
+      block:
+        - name: Fetch deploy key
+          ansible.builtin.set_fact:
+            deploy_key_creds: "{{ lookup('community.hashi_vault.vault_kv2_get',
+                                   'infra/deploy-keys/resume',
+                                   engine_mount_point='kv',
+                                   url=openbao_addr,
+                                   token=openbao_token,
+                                   validate_certs=openbao_validate_certs).secret }}"
+          no_log: true
+
+        - name: Validate deploy key
+          ansible.builtin.assert:
+            that:
+              - deploy_key_creds.private_key is defined
+              - deploy_key_creds.private_key | length > 0
+            fail_msg: "Deploy key missing - check OpenBao secret at kv/infra/deploy-keys/resume"
+      rescue:
+        - name: Fail with helpful error
+          ansible.builtin.fail:
+            msg: >
+              Failed to retrieve deploy key from OpenBao.
+              Ensure BAO_TOKEN is valid and secret exists at:
+                kv/infra/deploy-keys/resume (field: private_key)
+
+    - name: Create testing directory
+      ansible.builtin.file:
+        path: /opt/testing
+        state: directory
+        owner: deploy
+        group: deploy
+        mode: '0750'
+
+    - name: Copy Dockerfile
+      ansible.builtin.copy:
+        src: /work-testing/Dockerfile
+        dest: /opt/testing/Dockerfile
+        owner: deploy
+        group: deploy
+        mode: '0644'
+      register: dockerfile_result
+
+    - name: Copy entrypoint script
+      ansible.builtin.copy:
+        src: /work-testing/entrypoint.sh
+        dest: /opt/testing/entrypoint.sh
+        owner: deploy
+        group: deploy
+        mode: '0755'
+      register: entrypoint_result
+
+    - name: Copy docker-compose file
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../files/testing/docker-compose.yml"
+        dest: /opt/testing/docker-compose.yml
+        owner: deploy
+        group: deploy
+        mode: '0644'
+      register: compose_result
+
+    - name: Deploy SSH deploy key
+      ansible.builtin.copy:
+        content: "{{ deploy_key_creds.private_key }}"
+        dest: /opt/testing/deploy_key
+        owner: deploy
+        group: deploy
+        mode: '0600'
+      no_log: true
+
+    - name: Deploy environment file
+      ansible.builtin.copy:
+        content: |
+          # Managed by Ansible - do not edit manually
+          # Re-deploy with: make ansible-testing-deploy
+          RESUME_BRANCH={{ resume_branch }}
+        dest: /opt/testing/.env
+        owner: deploy
+        group: deploy
+        mode: '0644'
+      register: env_result
+
+    - name: Build testing container image
+      ansible.builtin.command:
+        cmd: docker compose build
+        chdir: /opt/testing
+      become_user: deploy
+      when:
+        - not ansible_check_mode
+        - dockerfile_result.changed or entrypoint_result.changed
+
+    - name: Ensure testing container is running
+      ansible.builtin.command:
+        cmd: docker compose up -d
+        chdir: /opt/testing
+      become_user: deploy
+      when:
+        - not ansible_check_mode

--- a/ansible/playbooks/testing-refresh.yml
+++ b/ansible/playbooks/testing-refresh.yml
@@ -1,0 +1,31 @@
+---
+# Restart the resume testing container to pull latest code from GitHub
+# The entrypoint runs git pull on every start, so restart = fresh code.
+#
+# Usage: make ansible-testing-refresh
+# Switch branch: make ansible-testing-switch BRANCH=master
+
+- name: Refresh resume testing container
+  hosts: container_hosts
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Update branch in .env
+      ansible.builtin.copy:
+        content: |
+          # Managed by Ansible - do not edit manually
+          # Re-deploy with: make ansible-testing-deploy
+          RESUME_BRANCH={{ resume_branch }}
+        dest: /opt/testing/.env
+        owner: deploy
+        group: deploy
+        mode: '0644'
+      when: resume_branch is defined
+
+    - name: Restart testing container
+      ansible.builtin.command:
+        cmd: docker compose restart resume-testing
+        chdir: /opt/testing
+      become_user: deploy
+      when: not ansible_check_mode

--- a/ansible/roles/nsd/templates/lan.quietlife.net.zone.j2
+++ b/ansible/roles/nsd/templates/lan.quietlife.net.zone.j2
@@ -44,3 +44,4 @@ radarr          IN      CNAME   containers
 sonarr          IN      CNAME   containers
 paperless       IN      CNAME   containers
 owncast         IN      CNAME   containers
+preview         IN      CNAME   containers

--- a/backup/scripts/backup-remote.sh
+++ b/backup/scripts/backup-remote.sh
@@ -101,12 +101,6 @@ if ! command -v rclone &>/dev/null; then
     exit 1
 fi
 
-# Verify rclone can reach the remote (checks credentials)
-if ! rclone lsd "${REMOTE}:" --max-depth 0 &>/dev/null; then
-    echo "ERROR: cannot list ${REMOTE}: — check rclone credentials" >&2
-    exit 1
-fi
-
 # ---------------------------------------------------------------------------
 # Read paths (skip comments and blank lines)
 # ---------------------------------------------------------------------------

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:3.1-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /site
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -1,0 +1,17 @@
+DC := docker compose
+
+.PHONY: help build clean
+
+.DEFAULT_GOAL := help
+
+help: ## Show this help
+	@echo "Testing container tooling (local build/test)"
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
+
+build: ## Build the resume-testing Docker image
+	docker build -t resume-testing .
+
+clean: ## Remove the resume-testing Docker image
+	docker rmi resume-testing 2>/dev/null || true

--- a/testing/entrypoint.sh
+++ b/testing/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_URL="${RESUME_REPO_URL:-git@github.com:cwage/resume.git}"
+BRANCH="${RESUME_BRANCH:-add-github-experience-multiline-yaml}"
+DEPLOY_KEY="/run/secrets/deploy_key"
+
+# Set up SSH with deploy key
+if [ -f "${DEPLOY_KEY}" ]; then
+  echo "==> Configuring SSH with deploy key"
+  mkdir -p ~/.ssh
+  cp "${DEPLOY_KEY}" ~/.ssh/id_ed25519
+  chmod 600 ~/.ssh/id_ed25519
+  # Add GitHub's host keys
+  ssh-keyscan -t ed25519,rsa github.com >> ~/.ssh/known_hosts 2>/dev/null
+else
+  echo "WARNING: No deploy key found at ${DEPLOY_KEY}, git clone may fail for private repos"
+fi
+
+if [ -d /site/.git ]; then
+  echo "==> Existing repo found, pulling latest from branch: ${BRANCH}"
+  cd /site
+  git fetch origin
+  git checkout "${BRANCH}"
+  git reset --hard "origin/${BRANCH}"
+else
+  echo "==> Cloning ${REPO_URL} (branch: ${BRANCH})"
+  git clone -b "${BRANCH}" "${REPO_URL}" /site
+  cd /site
+fi
+
+echo "==> Installing gems..."
+bundle install
+
+echo "==> Starting Jekyll on 0.0.0.0:4000"
+exec bundle exec jekyll serve --host 0.0.0.0


### PR DESCRIPTION
Add a Jekyll-based resume preview container that clones the private resume repo via SSH deploy key (fetched from OpenBao at deploy time) and serves it behind traefik at `preview.lan.quietlife.net`. Cloudflared can route `preview.quietlife.net` for external sharing.

Changes
- `testing/` — Dockerfile, entrypoint, and local Makefile for the resume-testing container
- `ansible/playbooks/testing-deploy.yml` — full deploy playbook (copies files, fetches deploy key from OpenBao, builds image, starts container)
- `ansible/playbooks/testing-refresh.yml` — lightweight restart playbook (git pull + jekyll rebuild)
- `ansible/files/testing/docker-compose.yml` — production compose with traefik labels and proxy network
- `ansible/Makefile` / root `Makefile` — new targets: `testing-deploy`, `testing-deploy-check`, `testing-refresh`, `testing-switch`
- `ansible/docker-compose.yml` — mount `testing/` into Ansible container
- DNS: added `preview` CNAME to `lan.quietlife.net` zone, bumped serial
- `README.md` — documented new testing targets and workflow
- `backup/scripts/backup-remote.sh` — removed premature rclone credential check that failed before config was loaded

Workflow
- Edit resume, `git push`, `make ansible-testing-refresh` to see changes
- `make ansible-testing-switch BRANCH=foo` to preview a different branch
- Deploy key stored in OpenBao at `kv/infra/deploy-keys/resume`
