### PR TITLE
Move cwage password hash to OpenBao

### DIFF
--- a/ansible/inventories/group_vars/all.yml
+++ b/ansible/inventories/group_vars/all.yml
@@ -26,7 +26,12 @@ managed_users:
     shell: /bin/bash
     groups: ["sudo"]
     sudo_nopasswd: false
-    password_hash: "$6$7fU9thowiE/0QSde$jpnJcpG0DVZpQ5OzOOgeuPg5OTBsiKsL0ats0geIZRoR5m0RLlnmGBrjnJtNk7Rfn4gm6wp8BBlHJCWZ6xFIT1"
+    password_hash: "{{ lookup('community.hashi_vault.vault_kv2_get',
+                       'infra/users/cwage',
+                       engine_mount_point=openbao_kv_mount,
+                       url=openbao_addr,
+                       token=openbao_token,
+                       validate_certs=openbao_validate_certs).secret.password_hash }}"
     ssh_pubkey_files:
       - "inventories/keys/cwage-portaplotz.pub"
       - "inventories/keys/cwage-portaptty.pub"

--- a/ansible/inventories/group_vars/gaming_servers.yml
+++ b/ansible/inventories/group_vars/gaming_servers.yml
@@ -14,7 +14,12 @@ managed_users:
     shell: /bin/bash
     groups: ["sudo"]
     sudo_nopasswd: false
-    password_hash: "$6$7fU9thowiE/0QSde$jpnJcpG0DVZpQ5OzOOgeuPg5OTBsiKsL0ats0geIZRoR5m0RLlnmGBrjnJtNk7Rfn4gm6wp8BBlHJCWZ6xFIT1"
+    password_hash: "{{ lookup('community.hashi_vault.vault_kv2_get',
+                       'infra/users/cwage',
+                       engine_mount_point=openbao_kv_mount,
+                       url=openbao_addr,
+                       token=openbao_token,
+                       validate_certs=openbao_validate_certs).secret.password_hash }}"
     ssh_pubkey_files:
       - "inventories/keys/cwage-portaplotz.pub"
       - "inventories/keys/cwage-portaptty.pub"


### PR DESCRIPTION
Move the `cwage` user password hash from hardcoded values in `group_vars/all.yml` and `group_vars/gaming_servers.yml` to OpenBao at `kv/infra/users/cwage`. Hash is now fetched at runtime via `community.hashi_vault.vault_kv2_get` lookup.

Changes
- Replace hardcoded `$6$...` password hash with OpenBao lookup in both files
- Tested with `--check --diff -v` against pve1 — lookup resolves, no changes detected

Also verified as part of #140:
- Trufflehog scan (filesystem + full git history) — zero findings
- `.gitignore` audit — solid coverage across all directories
- `.env.example` — placeholders only, no secrets

Remaining #140 items (not code changes):
- Rotate cwage password hash post-publish (was in git history before scrub)
- Decision on felix SSH port exposure
- Nginx basic_auth hashes staying as-is (not sensitive)
- Re-enable branch protection rule on master
