### PR TITLE
Fix stale README reference to git-tracked tfstate

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ make install-precommit-hook  # install trufflehog pre-commit hook
 
 - Root `.env` (gitignored): OpenBao credentials (BAO_ADDR, BAO_TOKEN) and Proxmox API credentials — shared by both Ansible and OpenTofu via `--env-file`
 - Ansible deploy keys: `ansible/keys/` (gitignored)
-- Tofu state: `tofu/terraform.tfstate` (tracked in git — single-developer workflow)
+- Tofu state: stored on NAS via NFS (not in git — see `TOFU_STATE_PATH` in `.env`)
 
 ## Documentation
 


### PR DESCRIPTION
One-liner: README still said tfstate was tracked in git. Updated to reflect the NFS migration from PR #148.