### PR TITLE
Remove preview DNS record

### DIFF
--- a/ansible/roles/nsd/templates/lan.quietlife.net.zone.j2
+++ b/ansible/roles/nsd/templates/lan.quietlife.net.zone.j2
@@ -44,4 +44,3 @@ radarr          IN      CNAME   containers
 sonarr          IN      CNAME   containers
 paperless       IN      CNAME   containers
 owncast         IN      CNAME   containers
-preview         IN      CNAME   containers

--- a/docs/dns.md
+++ b/docs/dns.md
@@ -18,7 +18,7 @@ LAN clients → fw1 (Unbound, recursive) → dns1 (NSD, authoritative)
 Managed in `ansible/roles/nsd/templates/lan.quietlife.net.zone.j2`. Current records include:
 
 - A records for infrastructure: fw1, dns1, pve1, containers, portanas, bao, etc.
-- CNAMEs for services: jellyfin, radarr, sonarr, sabnzbd, paperless, owncast, traefik, preview — all pointing to `containers`
+- CNAMEs for services: jellyfin, radarr, sonarr, sabnzbd, paperless, owncast, traefik — all pointing to `containers`
 - Convenience aliases: `firewall` → fw1, `nas` → portanas, `proxmox` → pve1
 
 ### Deployment


### PR DESCRIPTION
Remove the `preview.lan.quietlife.net` CNAME from the NSD zone template and update dns.md to match.

Changes
- Removed `preview IN CNAME containers` from `lan.quietlife.net.zone.j2`
- Updated service CNAME list in `docs/dns.md`

After merging, deploy with `make ansible-dns` to push the updated zone to dns1. Cloudflare tunnel route and external DNS should be cleaned up separately in the dashboard.
