### PR TITLE
Point staticomment at quietlife.net production repo

### DIFF
--- a/ansible/playbooks/containers.yml
+++ b/ansible/playbooks/containers.yml
@@ -166,9 +166,9 @@
         content: |
           # Managed by Ansible - do not edit manually
           CLOUDFLARE_TUNNEL_TOKEN={{ cloudflare_tunnel.token | default('') }}
-          STATICOMMENT_GIT_REPO=git@github.com:cwage/staticomment-test.git
-          STATICOMMENT_BRANCH=main
-          STATICOMMENT_ALLOWED_ORIGINS=https://staticomment.lan.quietlife.net
+          STATICOMMENT_GIT_REPO=git@github.com:cwage/quietlife.net.git
+          STATICOMMENT_BRANCH=master
+          STATICOMMENT_ALLOWED_ORIGINS=https://quietlife.net
         dest: /opt/stacks/.env
         owner: deploy
         group: deploy


### PR DESCRIPTION
Point staticomment at the live quietlife.net Jekyll repo instead of the test repo.

Changes
- Repo: `cwage/staticomment-test.git` → `cwage/quietlife.net.git`
- Branch: `main` → `master`
- Allowed origins: `https://staticomment.lan.quietlife.net` → `https://quietlife.net`

The existing SSH deploy key in OpenBao is reused — just needs to be added to the new repo as a deploy key with write access.
