### PR TITLE
Bump staticomment to v0.2.0

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -172,7 +172,7 @@ services:
       - proxy
 
   staticomment:
-    image: ghcr.io/cwage/staticomment:0.1.0
+    image: ghcr.io/cwage/staticomment:0.2.0
     container_name: staticomment
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Bump staticomment from v0.1.0 to v0.2.0.

Changes in v0.2.0
- `reply_to` field support for threaded comments
- Post slug existence validation
- Integration test suite

This fixes replies not being saved — the deployed v0.1.0 image predated the reply_to feature.
