### PR TITLE
Move container config volumes to NAS

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - PGID=1000
       - TZ=America/Chicago
     volumes:
-      - jellyfin_config:/config
-      - jellyfin_cache:/cache
+      - /mnt/nas/containers-configs/jellyfin:/config
+      - /mnt/nas/containers-configs/jellyfin-cache:/cache
       - /mnt/nas/Media:/media
     labels:
       - "traefik.enable=true"
@@ -68,7 +68,7 @@ services:
       - PGID=1000
       - TZ=America/Chicago
     volumes:
-      - sabnzbd_config:/config
+      - /mnt/nas/containers-configs/sabnzbd:/config
       - /mnt/nas/Media:/media
     labels:
       - "traefik.enable=true"
@@ -88,7 +88,7 @@ services:
       - PGID=1000
       - TZ=America/Chicago
     volumes:
-      - radarr_config:/config
+      - /mnt/nas/containers-configs/radarr:/config
       - /mnt/nas/Media:/media
     labels:
       - "traefik.enable=true"
@@ -108,7 +108,7 @@ services:
       - PGID=1000
       - TZ=America/Chicago
     volumes:
-      - sonarr_config:/config
+      - /mnt/nas/containers-configs/sonarr:/config
       - /mnt/nas/Media:/media
     labels:
       - "traefik.enable=true"
@@ -124,7 +124,7 @@ services:
     container_name: paperless-redis
     restart: unless-stopped
     volumes:
-      - paperless_redis:/data
+      - /mnt/nas/containers-configs/paperless-redis:/data
     networks:
       - proxy
 
@@ -161,7 +161,7 @@ services:
     ports:
       - "10.10.15.12:1935:1935"
     volumes:
-      - owncast_data:/app/data
+      - /mnt/nas/containers-configs/owncast:/app/data
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.owncast.rule=Host(`owncast.lan.quietlife.net`)"
@@ -210,11 +210,3 @@ networks:
   proxy:
     name: proxy
 
-volumes:
-  jellyfin_config:
-  jellyfin_cache:
-  sabnzbd_config:
-  radarr_config:
-  sonarr_config:
-  paperless_redis:
-  owncast_data:

--- a/ansible/inventories/group_vars/container_hosts.yml
+++ b/ansible/inventories/group_vars/container_hosts.yml
@@ -24,6 +24,10 @@ ntfy_backup_topic: "https://ntfy.sh/cwage-homelab-backup"
 # Media and paperless are rw (needed by radarr/sonarr/sabnzbd/paperless-ngx)
 # Everything else is ro (backup, general access)
 nfs_mounts:
+  - name: containers-configs
+    src: 10.10.15.4:/volume1/containers-configs
+    path: /mnt/nas/containers-configs
+    opts: "rw,_netdev,hard,vers=3,noatime"
   - name: media
     src: 10.10.15.4:/volume1/Media
     path: /mnt/nas/Media

--- a/ansible/playbooks/containers.yml
+++ b/ansible/playbooks/containers.yml
@@ -18,6 +18,22 @@
     - nvidia_container
 
   tasks:
+    - name: Create container config directories on NAS
+      ansible.builtin.file:
+        path: "/mnt/nas/containers-configs/{{ item }}"
+        state: directory
+        owner: deploy
+        group: deploy
+        mode: '0755'
+      loop:
+        - jellyfin
+        - jellyfin-cache
+        - sabnzbd
+        - radarr
+        - sonarr
+        - paperless-redis
+        - owncast
+
     - name: Create stacks directory
       ansible.builtin.file:
         path: /opt/stacks


### PR DESCRIPTION
Move container config volumes (jellyfin, radarr, sonarr, sabnzbd, owncast, paperless-redis) from Docker named volumes on the VM's local disk to NFS bind mounts on the NAS.

This ensures config data survives VM recreation — a prerequisite for the upcoming generic image rebuild (#113).

Changes
- Add `containers-configs` NFS mount (rw) to `container_hosts` group vars
- Replace all named volumes with bind mounts under `/mnt/nas/containers-configs/`
- Add Ansible task to create config subdirectories on the NAS mount
- Remove the `volumes:` block from stacks `docker-compose.yml`

NAS share `containers-configs` was created manually in DSM. Data was migrated from Docker volumes on the live VM before deploying.
