### PR TITLE
Hardware audit: fill in specs for all physical hosts

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -15,7 +15,7 @@ graph TD
 
     subgraph LAN["LAN — 10.10.15.0/24"]
         fw1["fw1 (.1)<br/><small>OpenBSD · pf · DHCP · Unbound · WireGuard</small>"]
-        portanas["portanas (.4)<br/><small>Synology DS1815+ · NFS storage</small>"]
+        portanas["portanas (.4)<br/><small>Synology DS1817+ · NFS storage</small>"]
 
         subgraph pve1["pve1 (.18) — Proxmox VE · Ryzen 7 1800X · 64 GB"]
             dns1["dns1 (.10)<br/><small>NSD authoritative DNS</small>"]
@@ -44,22 +44,42 @@ The sole physical server, running Proxmox VE. All local VMs run on this host.
 | Motherboard | Gigabyte AX370-Gaming-CF (AM4) |
 | CPU | AMD Ryzen 7 1800X — 8 cores / 16 threads @ 3.6 GHz |
 | Memory | 64 GB DDR4 |
-| Boot disk | 250 GB SATA SSD (WD Blue) |
-| Data disk | 1 TB SATA HDD (WD Blue) |
-| GPU | NVIDIA GeForce GTX 1050 Ti (passed through to containers VM) |
+| Boot disk | 250 GB SATA SSD (WDS250G1B0B) |
+| Data disk | 1 TB SATA HDD (WDC WD10EZEX) |
+| GPU | NVIDIA GeForce GTX 1050 Ti GP107 (passed through to containers VM) |
 | NIC | Realtek RTL8111 PCIe Gigabit |
+| Hypervisor | Proxmox VE 9.1.4 (kernel 6.17.4-2-pve) |
 
 ### fw1 — OpenBSD firewall
 
-<!-- TODO: document hardware specs -->
+Protectli Vault FW4B. Runs OpenBSD. Serves as the LAN gateway, DHCP server, recursive DNS resolver (Unbound), and WireGuard VPN endpoint.
 
-Runs OpenBSD. Serves as the LAN gateway, DHCP server, recursive DNS resolver (Unbound), and WireGuard VPN endpoint.
+| Component | Spec |
+|-----------|------|
+| Model | Protectli Vault FW4B |
+| CPU | Intel Celeron J3160 — 4 cores @ 1.60 GHz |
+| Memory | 2.7 GB DDR3L |
+| Boot disk | 128 GB mSATA SSD (BIWIN) |
+| NICs | 4x Intel Gigabit (em0–em3) |
+| OS | OpenBSD 7.1 (i386) |
+
+NIC assignments: em0 (WAN), em1 (LAN — 10.10.15.1), em2–em3 unused.
 
 ### portanas — Synology NAS
 
-<!-- TODO: document model and drive configuration -->
+Synology DS1817+. Provides NFS exports for media, documents, and backups.
 
-Synology DS1815+. Provides NFS exports for media, documents, and backups.
+| Component | Spec |
+|-----------|------|
+| Model | Synology DS1817+ |
+| CPU | Intel Atom C2538 — 4 cores @ 2.40 GHz |
+| Memory | 8 GB DDR3 |
+| Drive bays | 8 (6 populated) |
+| Drives | 6x WD Red Pro 6 TB (WD6002FFWX) |
+| RAID | RAID 5 — ~27 TB usable (6.3 TB used, 24%) |
+| USB | Seagate 8 TB external at /volumeUSB1 |
+| NICs | 4x Gigabit (eth0–eth3, only eth0 active) |
+| DSM | 7.1.1-42962 Update 9 |
 
 ## Virtual machines
 


### PR DESCRIPTION
Hardware audit of all physical hosts — probed live systems via SSH to fill in specs.

Changes
- **fw1**: Added full spec table (Protectli FW4B, Celeron J3160, 2.7 GB, 128 GB mSATA, 4x Intel GbE, NIC assignments)
- **portanas**: Corrected model from DS1815+ to DS1817+, added spec table (Atom C2538, 8 GB, 6x WD Red Pro 6 TB RAID5, DSM version)
- **pve1**: Updated drive model numbers to exact part numbers, added Proxmox version
- Removed all TODO placeholders from hardware doc

Test Plan
- Verify markdown renders correctly on GitHub (tables, mermaid diagram)
