### PR TITLE
Add homelab-backups to backup targets

### DIFF
--- a/ansible/inventories/group_vars/container_hosts.yml
+++ b/ansible/inventories/group_vars/container_hosts.yml
@@ -101,3 +101,7 @@ nfs_mounts:
     src: 10.10.15.4:/volume1/Videoold
     path: /mnt/nas/Videoold
     opts: "ro,_netdev,hard,nofail,vers=3,noatime"
+  - name: homelab-backups
+    src: 10.10.15.4:/volume1/homelab-backups
+    path: /mnt/nas/homelab-backups
+    opts: "ro,_netdev,hard,nofail,vers=3,noatime"

--- a/ansible/roles/openbao/tasks/main.yml
+++ b/ansible/roles/openbao/tasks/main.yml
@@ -170,7 +170,7 @@
         state: directory
         owner: root
         group: root
-        mode: "0750"
+        mode: "0755"
 
     - name: Deploy backup script
       ansible.builtin.template:

--- a/ansible/roles/openbao/templates/openbao-backup.sh.j2
+++ b/ansible/roles/openbao/templates/openbao-backup.sh.j2
@@ -38,13 +38,16 @@ else
     exit 1
 fi
 
-# Create backup directory if it doesn't exist (with secure permissions)
+# Create backup directory if it doesn't exist
+# 0755 so the NAS backup pipeline can read snapshots via NFS
+# (snapshot contents are only useful with the unseal key)
 mkdir -p "${BACKUP_DIR}"
-chmod 0750 "${BACKUP_DIR}"
+chmod 0755 "${BACKUP_DIR}"
 
 # Take Raft snapshot
 echo "Taking Raft snapshot to ${SNAPSHOT_FILE}"
 bao operator raft snapshot save "${SNAPSHOT_FILE}"
+chmod 0644 "${SNAPSHOT_FILE}"
 
 # Clean up old backups
 echo "Removing backups older than ${RETENTION_DAYS} days"

--- a/backup/targets/b2.txt
+++ b/backup/targets/b2.txt
@@ -12,3 +12,4 @@ syncthing-data
 backup
 Misc
 Media
+homelab-backups

--- a/backup/targets/local.txt
+++ b/backup/targets/local.txt
@@ -12,3 +12,4 @@ backup
 Misc
 Media
 tb
+homelab-backups


### PR DESCRIPTION
Add OpenBao Raft snapshots to the backup pipeline so they get synced to both USB and B2 alongside NAS data.

Changes
- Mount `homelab-backups` NFS share on containers VM at `/mnt/nas/homelab-backups` (ro)
- Add `homelab-backups` to both `targets/local.txt` and `targets/b2.txt`
- Relax OpenBao snapshot permissions to `0755`/`0644` so the non-root backup container can read them (snapshot contents require unseal key to restore, so read access is not a security concern)

Note
- DSM NFS share permissions for `homelab-backups` needed manual update to allow access from the containers VM (10.10.15.12) — previously only the openbao VM had access

Test Plan
- Deployed `make ansible-openbao` — verified new snapshots created with `0644` permissions
- Deployed NFS mount on containers VM, verified `homelab-backups` visible inside backup container
