### PR TITLE
Switch container configs to named Docker volumes

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - PGID=1000
       - TZ=America/Chicago
     volumes:
-      - /mnt/nas/containers-configs/jellyfin:/config
-      - /mnt/nas/containers-configs/jellyfin-cache:/cache
+      - jellyfin_config:/config
+      - jellyfin_cache:/cache
       - /mnt/nas/Media:/media
     labels:
       - "traefik.enable=true"
@@ -68,7 +68,7 @@ services:
       - PGID=1000
       - TZ=America/Chicago
     volumes:
-      - /mnt/nas/containers-configs/sabnzbd:/config
+      - sabnzbd_config:/config
       - /mnt/nas/Media:/media
     labels:
       - "traefik.enable=true"
@@ -88,7 +88,7 @@ services:
       - PGID=1000
       - TZ=America/Chicago
     volumes:
-      - /mnt/nas/containers-configs/radarr:/config
+      - radarr_config:/config
       - /mnt/nas/Media:/media
     labels:
       - "traefik.enable=true"
@@ -108,7 +108,7 @@ services:
       - PGID=1000
       - TZ=America/Chicago
     volumes:
-      - /mnt/nas/containers-configs/sonarr:/config
+      - sonarr_config:/config
       - /mnt/nas/Media:/media
     labels:
       - "traefik.enable=true"
@@ -125,7 +125,7 @@ services:
     restart: unless-stopped
     user: "${UID:-1000}:${GID:-1000}"
     volumes:
-      - /mnt/nas/containers-configs/paperless-redis:/data
+      - paperless_redis:/data
     networks:
       - proxy
 
@@ -163,7 +163,7 @@ services:
     ports:
       - "10.10.15.12:1935:1935"
     volumes:
-      - /mnt/nas/containers-configs/owncast:/app/data
+      - owncast_data:/app/data
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.owncast.rule=Host(`owncast.lan.quietlife.net`)"
@@ -207,6 +207,15 @@ services:
       - owncast
     profiles:
       - tunnel
+
+volumes:
+  jellyfin_config:
+  jellyfin_cache:
+  sabnzbd_config:
+  radarr_config:
+  sonarr_config:
+  paperless_redis:
+  owncast_data:
 
 networks:
   proxy:

--- a/ansible/inventories/group_vars/container_hosts.yml
+++ b/ansible/inventories/group_vars/container_hosts.yml
@@ -25,10 +25,6 @@ ntfy_backup_topic: "https://ntfy.sh/cwage-homelab-backup"
 # Media and paperless are rw (needed by radarr/sonarr/sabnzbd/paperless-ngx)
 # Everything else is ro (backup, general access)
 nfs_mounts:
-  - name: containers-configs
-    src: 10.10.15.4:/volume1/containers-configs
-    path: /mnt/nas/containers-configs
-    opts: "rw,_netdev,hard,vers=3,noatime"
   - name: media
     src: 10.10.15.4:/volume1/Media
     path: /mnt/nas/Media

--- a/ansible/playbooks/containers.yml
+++ b/ansible/playbooks/containers.yml
@@ -18,22 +18,6 @@
     - nvidia_container
 
   tasks:
-    - name: Create container config directories on NAS
-      ansible.builtin.file:
-        path: "/mnt/nas/containers-configs/{{ item }}"
-        state: directory
-        owner: deploy
-        group: deploy
-        mode: '0755'
-      loop:
-        - jellyfin
-        - jellyfin-cache
-        - sabnzbd
-        - radarr
-        - sonarr
-        - paperless-redis
-        - owncast
-
     - name: Mount USB backup drive
       ansible.posix.mount:
         path: /mnt/nasbak


### PR DESCRIPTION
Switch container config storage from NAS bind mounts to named Docker volumes.

Changes
- Replace `/mnt/nas/containers-configs/*` bind mounts with named Docker volumes for jellyfin, sabnzbd, radarr, sonarr, paperless-redis, and owncast
- Remove NFS mount configuration from `container_hosts.yml` and `containers.yml` since those NAS shares are no longer needed for config storage

Test Plan
- Already deployed and running on containers VM
