### PR TITLE
Add nofail to PVE NFS mounts to prevent boot hangs

### DIFF
--- a/ansible/inventories/host_vars/pve1.yml
+++ b/ansible/inventories/host_vars/pve1.yml
@@ -5,11 +5,11 @@ nfs_mounts:
   - name: backup
     src: 10.10.15.4:/volume1/pve-backups
     path: /mnt/pve-backups
-    opts: "rw,_netdev,hard,vers=3,noatime"
+    opts: "rw,_netdev,hard,nofail,vers=3,noatime"
   - name: templates
     src: 10.10.15.4:/volume1/pve-templates
     path: /mnt/pve-templates
-    opts: "rw,_netdev,hard,vers=3,noatime"
+    opts: "rw,_netdev,hard,nofail,vers=3,noatime"
 
 # GPU passthrough configuration for GTX 1050 Ti
 # IOMMU Group 14: GPU (07:00.0) + Audio (07:00.1)


### PR DESCRIPTION
## Summary
- Add `nofail` mount option to both NFS mounts on pve1 (pve-backups and pve-templates)
- Prevents boot from hanging when the NFS server is unreachable (e.g. NIC unavailable after BIOS changes)
- Neither mount is critical at boot time, so the system can safely continue without them

Closes #50