### PR TITLE
Add basic auth to Traefik dashboard

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -22,12 +22,15 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./certs:/etc/traefik/certs:ro
       - ./traefik-tls.yml:/etc/traefik/tls.yml:ro
+      - ./traefik-basicauth:/etc/traefik/basicauth:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.traefik.rule=Host(`traefik.lan.quietlife.net`)"
       - "traefik.http.routers.traefik.entrypoints=websecure"
       - "traefik.http.routers.traefik.tls=true"
       - "traefik.http.routers.traefik.service=api@internal"
+      - "traefik.http.routers.traefik.middlewares=traefik-auth"
+      - "traefik.http.middlewares.traefik-auth.basicauth.usersfile=/etc/traefik/basicauth"
     networks:
       - proxy
 

--- a/ansible/playbooks/containers.yml
+++ b/ansible/playbooks/containers.yml
@@ -100,6 +100,40 @@
         mode: '0644'
       register: traefik_tls_result
 
+    - name: Retrieve Traefik basicauth credentials from OpenBao
+      block:
+        - name: Fetch Traefik basicauth from OpenBao
+          ansible.builtin.set_fact:
+            traefik_basicauth: "{{ lookup('community.hashi_vault.vault_kv2_get',
+                                   'infra/traefik/basicauth',
+                                   engine_mount_point='kv',
+                                   url=openbao_addr,
+                                   token=openbao_token,
+                                   validate_certs=openbao_validate_certs).secret }}"
+          no_log: true
+      rescue:
+        - name: Warn if Traefik basicauth not found (non-fatal)
+          ansible.builtin.debug:
+            msg: >
+              Traefik basicauth credentials not found in OpenBao at kv/infra/traefik/basicauth.
+              Dashboard will not have authentication.
+              Store with: htpasswd -nbB cwage <password> | bao kv put kv/infra/traefik/basicauth htpasswd=-
+        - name: Set empty basicauth
+          ansible.builtin.set_fact:
+            traefik_basicauth:
+              htpasswd: ""
+
+    - name: Deploy Traefik basicauth file
+      ansible.builtin.copy:
+        content: "{{ traefik_basicauth.htpasswd }}"
+        dest: /opt/stacks/traefik-basicauth
+        owner: deploy
+        group: deploy
+        mode: '0600'
+      register: traefik_basicauth_result
+      no_log: true
+      when: (traefik_basicauth.htpasswd | default('')) | length > 0
+
     - name: Retrieve Cloudflare Tunnel token from OpenBao
       block:
         - name: Fetch Cloudflare Tunnel token from OpenBao
@@ -202,6 +236,7 @@
              traefik_tls_result.changed or
              tls_cert_result.changed or
              tls_key_result.changed or
+             (traefik_basicauth_result.changed | default(false)) or
              env_result.changed or
              (force_restart | default(false)) }}
 


### PR DESCRIPTION
## Summary
- Adds BasicAuth middleware to the Traefik dashboard router
- Credentials (htpasswd format) are fetched from OpenBao at `kv/infra/traefik/basicauth`
- Non-fatal: if the secret is missing, the playbook warns and skips (dashboard remains unauthenticated)

Closes #46

## Test plan
- [x] Stored bcrypt htpasswd hash in OpenBao
- [x] Ran `make ansible-containers` — dashboard now prompts for credentials