### PR TITLE
Exclude incomplete downloads from backup

### DIFF
--- a/backup/scripts/backup.sh
+++ b/backup/scripts/backup.sh
@@ -210,6 +210,7 @@ RCLONE_FLAGS=(
     --exclude "*.db-wal"
     --exclude "*.db-shm"
     --exclude "**/logs/**"
+    --exclude "Downloads/incomplete/**"
 )
 
 if [[ -n "$LOG_FILE" ]]; then


### PR DESCRIPTION
Exclude `Downloads/incomplete/` from rclone backup sync to prevent transient file errors.

## Changes
- Add `Downloads/incomplete/**` to rclone exclusion list in `backup.sh`

## Context
The local backup was failing the entire `Media` path due to 541 "no such file or directory" errors. Files in the incomplete downloads directory were being extracted/cleaned up by the download client mid-sync, causing rclone to exit non-zero and trigger an ntfy failure alert. Incomplete downloads aren't worth backing up anyway.
