### PR TITLE
Add nash-services to container stack

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -239,6 +239,22 @@ services:
     networks:
       - proxy
 
+  nash-services:
+    image: ghcr.io/cwage/nash-services:main
+    container_name: nash-services
+    restart: unless-stopped
+    user: "${UID:-1000}:${GID:-1000}"
+    environment:
+      - PYTHONUNBUFFERED=1
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nash-services.rule=Host(`nash-services.lan.quietlife.net`)"
+      - "traefik.http.routers.nash-services.entrypoints=websecure"
+      - "traefik.http.routers.nash-services.tls=true"
+      - "traefik.http.services.nash-services.loadbalancer.server.port=5000"
+    networks:
+      - proxy
+
   cloudflared:
     image: cloudflare/cloudflared:2026.1.2
     container_name: cloudflared

--- a/ansible/roles/nsd/templates/lan.quietlife.net.zone.j2
+++ b/ansible/roles/nsd/templates/lan.quietlife.net.zone.j2
@@ -46,3 +46,4 @@ paperless       IN      CNAME   containers
 owncast         IN      CNAME   containers
 staticomment    IN      CNAME   containers
 mm              IN      CNAME   containers
+nash-services   IN      CNAME   containers


### PR DESCRIPTION
Add nash-services (Nashville Open Data proximity search) to the container stack.

Changes
- Add `nash-services` service to docker-compose using `ghcr.io/cwage/nash-services:main`
- Add DNS CNAME `nash-services.lan.quietlife.net` -> `containers`
- Traefik routing on port 5000, public via Cloudflare tunnel at `nash-services.quietlife.net`

No secrets, volumes, or additional config needed.
