### PR TITLE
Bump nash-services to v0.2.0

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -240,7 +240,7 @@ services:
       - proxy
 
   nash-services:
-    image: ghcr.io/cwage/nash-services:main
+    image: ghcr.io/cwage/nash-services:0.2.0
     container_name: nash-services
     restart: unless-stopped
     user: "${UID:-1000}:${GID:-1000}"


### PR DESCRIPTION
## Summary
- Pin nash-services image to v0.2.0 (was `:main`)
- v0.2.0 adds service cache with hot->cold status visualization and shareable URL state

## Test plan
- Deploy stack, verify nash-services container pulls the v0.2.0 image
- Confirm poller starts and caches active dispatch/fire/road closure data
- Verify web UI at nash-services.lan.quietlife.net
