### PR TITLE
Bump nash-services to v0.3.0

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -240,7 +240,7 @@ services:
       - proxy
 
   nash-services:
-    image: ghcr.io/cwage/nash-services:0.2.0
+    image: ghcr.io/cwage/nash-services:0.3.0
     container_name: nash-services
     restart: unless-stopped
     user: "${UID:-1000}:${GID:-1000}"


### PR DESCRIPTION
## Summary
- Bump nash-services from v0.2.0 to v0.3.0
- v0.3.0 adds date range filtering, MNPD sector visualization, featured presets (2020 Christmas Bombing), and Playwright test suite

## Test plan
- Deploy stack, verify nash-services pulls v0.3.0
- Confirm web UI at nash-services.quietlife.net loads featured preset and sector circles
