### PR TITLE
Bump nash-services to v0.6.0

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -240,7 +240,7 @@ services:
       - proxy
 
   nash-services:
-    image: ghcr.io/cwage/nash-services:0.4.0
+    image: ghcr.io/cwage/nash-services:0.6.0
     container_name: nash-services
     restart: unless-stopped
     user: "${UID:-1000}:${GID:-1000}"


### PR DESCRIPTION
Bump nash-services to v0.6.0

Changes
- Update `nash-services` image from `0.4.0` to `0.6.0` in docker-compose
- Skipped v0.5.0 release due to build bugs
