### PR TITLE
Fix dns1 hostname: prevent cloud-init override

### DIFF
--- a/hosts/dns1/configuration.nix
+++ b/hosts/dns1/configuration.nix
@@ -3,6 +3,12 @@
 {
   networking.hostName = "dns1";
 
+  # Prevent cloud-init from overriding the hostname (it cached "dns1-nixos" from
+  # the original VM creation and re-applies it on every boot)
+  environment.etc."cloud/cloud.cfg.d/99-preserve-hostname.cfg".text = ''
+    preserve_hostname: true
+  '';
+
   # --- NSD authoritative DNS for lan.quietlife.net ---
 
   # Disable systemd-resolved (conflicts with NSD on port 53)


### PR DESCRIPTION
Fix dns1 hostname stuck as "dns1-nixos" after NixOS migration.

## Changes
- Add `preserve_hostname: true` to cloud-init config on dns1
- Prevents cloud-init from overriding `networking.hostName` with the cached VM name from initial creation

## Context
After the NixOS migration (PR #192), the VM hostname was stuck as `dns1-nixos` despite `networking.hostName = "dns1"` in the NixOS config. Cloud-init cached the original VM name and re-applied it on every boot. The `preserve_hostname` setting tells cloud-init to leave the hostname alone, letting NixOS manage it.

## Test plan
- Deployed config and manually set `/etc/hostname` to `dns1`
- Rebooted VM — hostname persists as `dns1` across reboot
- Verified cloud-init logs show: `Configuration option 'preserve_hostname' is set, not updating the hostname`
