### PR TITLE
Bump nash-services to 0.10.1, wire GitHub token via OpenBao

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -240,13 +240,14 @@ services:
       - proxy
 
   nash-services:
-    image: ghcr.io/cwage/nash-services:0.9.0
+    image: ghcr.io/cwage/nash-services:0.10.1
     container_name: nash-services
     restart: unless-stopped
     user: "${UID:-1000}:${GID:-1000}"
     environment:
       - PYTHONUNBUFFERED=1
       - DISPATCH_CACHE_DB=/data/service_cache.db
+      - GITHUB_TOKEN=${NASH_SERVICES_GITHUB_TOKEN:-}
     volumes:
       - nash_services_cache:/data
     labels:

--- a/ansible/playbooks/containers.yml
+++ b/ansible/playbooks/containers.yml
@@ -249,6 +249,29 @@
             mattermost_db:
               password: ""
 
+    - name: Retrieve nash-services GitHub token from OpenBao
+      block:
+        - name: Fetch nash-services GitHub token from OpenBao
+          ansible.builtin.set_fact:
+            nash_services_github: "{{ lookup('community.hashi_vault.vault_kv2_get',
+                              'infra/nash-services/github',
+                              engine_mount_point='kv',
+                              url=openbao_addr,
+                              token=openbao_token,
+                              validate_certs=openbao_validate_certs).secret }}"
+          no_log: true
+      rescue:
+        - name: Warn if nash-services GitHub token not found (non-fatal)
+          ansible.builtin.debug:
+            msg: >
+              nash-services GitHub token not found in OpenBao at kv/infra/nash-services/github.
+              Bug report feature will not work without a GitHub PAT.
+              Store with: bao kv put kv/infra/nash-services/github token=<YOUR_PAT>
+        - name: Set empty GitHub token
+          ansible.builtin.set_fact:
+            nash_services_github:
+              token: ""
+
     - name: Deploy stacks environment file
       ansible.builtin.copy:
         content: |
@@ -259,6 +282,7 @@
           STATICOMMENT_ALLOWED_ORIGINS=https://quietlife.net
           MM_DB_PASSWORD={{ mattermost_db.password | default('') }}
           COTURN_AUTH_SECRET={{ coturn_auth.secret | default('') }}
+          NASH_SERVICES_GITHUB_TOKEN={{ nash_services_github.token | default('') }}
         dest: /opt/stacks/.env
         owner: deploy
         group: deploy


### PR DESCRIPTION
Bumps nash-services to 0.10.1 and wires in OpenBao support for the GitHub PAT needed by the new bug report feature (cwage/nash-services#11).

Changes
- Bump `nash-services` image from 0.9.0 to 0.10.1
- Add OpenBao secret retrieval block for `kv/infra/nash-services/github` in `containers.yml`
- Inject `NASH_SERVICES_GITHUB_TOKEN` into the stacks `.env` file
- Non-fatal if secret is missing — service starts without bug reporting

Test Plan
- Deployed and verified bug report feature works with the stored PAT
