### PR TITLE
Add cwage thinkpad SSH pubkey

### DIFF
--- a/ansible/inventories/group_vars/all.yml
+++ b/ansible/inventories/group_vars/all.yml
@@ -35,3 +35,4 @@ managed_users:
     ssh_pubkey_files:
       - "inventories/keys/cwage-portaplotz.pub"
       - "inventories/keys/cwage-portaptty.pub"
+      - "inventories/keys/cwage-thinkpad.pub"

--- a/ansible/inventories/keys/cwage-thinkpad.pub
+++ b/ansible/inventories/keys/cwage-thinkpad.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGZsWfwyzchgl6n/WaB73mWThOm7//IQqHK8tX4Cqueq cwage@thinkpad


### PR DESCRIPTION
## Summary
- Add `cwage-thinkpad.pub` ed25519 key to `ansible/inventories/keys/`
- Add it to the `ssh_pubkey_files` list in `group_vars/all.yml` so it deploys to all managed hosts

## Test plan
- [x] Ran `make run PLAY=playbooks/openbao.yml` — key deployed successfully, SSH access confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)