### PR TITLE
Add linkding bookmark manager

### DIFF
--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -259,6 +259,25 @@ services:
     networks:
       - proxy
 
+  linkding:
+    image: sissbruecker/linkding:latest
+    container_name: linkding
+    restart: unless-stopped
+    volumes:
+      - linkding_data:/etc/linkding/data
+    environment:
+      - LD_SUPERUSER_NAME=${LINKDING_SUPERUSER_NAME}
+      - LD_SUPERUSER_PASSWORD=${LINKDING_SUPERUSER_PASSWORD}
+      - LD_CSRF_TRUSTED_ORIGINS=https://links.lan.quietlife.net
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.linkding.rule=Host(`links.lan.quietlife.net`)"
+      - "traefik.http.routers.linkding.entrypoints=websecure"
+      - "traefik.http.routers.linkding.tls=true"
+      - "traefik.http.services.linkding.loadbalancer.server.port=9090"
+    networks:
+      - proxy
+
   cloudflared:
     image: cloudflare/cloudflared:2026.1.2
     container_name: cloudflared
@@ -290,6 +309,7 @@ volumes:
   mattermost_client_plugins:
   mattermost_bleve:
   nash_services_cache:
+  linkding_data:
 
 networks:
   proxy:

--- a/ansible/files/stacks/docker-compose.yml
+++ b/ansible/files/stacks/docker-compose.yml
@@ -260,7 +260,7 @@ services:
       - proxy
 
   linkding:
-    image: sissbruecker/linkding:latest
+    image: sissbruecker/linkding:1.45.0
     container_name: linkding
     restart: unless-stopped
     volumes:

--- a/ansible/playbooks/containers.yml
+++ b/ansible/playbooks/containers.yml
@@ -272,6 +272,30 @@
             nash_services_github:
               token: ""
 
+    - name: Retrieve linkding superuser credentials from OpenBao
+      block:
+        - name: Fetch linkding superuser credentials from OpenBao
+          ansible.builtin.set_fact:
+            linkding_superuser: "{{ lookup('community.hashi_vault.vault_kv2_get',
+                              'infra/linkding/superuser',
+                              engine_mount_point='kv',
+                              url=openbao_addr,
+                              token=openbao_token,
+                              validate_certs=openbao_validate_certs).secret }}"
+          no_log: true
+      rescue:
+        - name: Warn if linkding superuser credentials not found (non-fatal)
+          ansible.builtin.debug:
+            msg: >
+              linkding superuser credentials not found in OpenBao at kv/infra/linkding/superuser.
+              linkding will start without a pre-configured admin account.
+              Store with: bao kv put kv/infra/linkding/superuser name=<USERNAME> password=<PASSWORD>
+        - name: Set empty linkding superuser credentials
+          ansible.builtin.set_fact:
+            linkding_superuser:
+              name: ""
+              password: ""
+
     - name: Deploy stacks environment file
       ansible.builtin.copy:
         content: |
@@ -283,6 +307,8 @@
           MM_DB_PASSWORD={{ mattermost_db.password | default('') }}
           COTURN_AUTH_SECRET={{ coturn_auth.secret | default('') }}
           NASH_SERVICES_GITHUB_TOKEN={{ nash_services_github.token | default('') }}
+          LINKDING_SUPERUSER_NAME={{ linkding_superuser.name | default('') }}
+          LINKDING_SUPERUSER_PASSWORD={{ linkding_superuser.password | default('') }}
         dest: /opt/stacks/.env
         owner: deploy
         group: deploy

--- a/docs/openbao-secrets.md
+++ b/docs/openbao-secrets.md
@@ -19,6 +19,9 @@ kv/
 │   │       └── api_token, account_id    # OpenTofu Cloudflare provider (DNS + tunnel mgmt)
 │   ├── certs/                # TLS certificates (Let's Encrypt)
 │   │   └── lan.quietlife.net # Wildcard cert for *.lan.quietlife.net
+│   ├── linkding/             # Linkding bookmark manager
+│   │   └── superuser/
+│   │       └── name, password             # Admin account credentials
 │   └── ssh/                  # SSH keys (if stored here)
 │
 ├── services/                 # Application/service secrets

--- a/docs/services.md
+++ b/docs/services.md
@@ -14,6 +14,7 @@ All self-hosted services run as Docker containers on the **containers** host (`1
 | **Paperless-ngx** | `paperless-ngx/paperless-ngx` | `https://paperless.lan.quietlife.net` | Document management |
 | **Owncast** | `owncast/owncast` | `https://owncast.lan.quietlife.net` | Live streaming (RTMP ingest on port 1935) |
 | **Cloudflared** | `cloudflare/cloudflared` | — | Cloudflare Tunnel for external access |
+| **Linkding** | `sissbruecker/linkding` | `https://links.lan.quietlife.net` | Bookmark manager |
 | **Paperless Redis** | `redis` | — | Backend for Paperless-ngx |
 
 ## External access

--- a/hosts/dns1/configuration.nix
+++ b/hosts/dns1/configuration.nix
@@ -31,7 +31,7 @@
           $TTL 300
 
           @       IN  SOA dns1.lan.quietlife.net. hostmaster.lan.quietlife.net. (
-                      2026031901  ; serial (YYYYMMDDNN)
+                      2026032601  ; serial (YYYYMMDDNN)
                       3600        ; refresh
                       600         ; retry
                       604800      ; expire
@@ -71,6 +71,7 @@
           staticomment    IN  CNAME   containers.lan.quietlife.net.
           mm              IN  CNAME   containers.lan.quietlife.net.
           nash-services   IN  CNAME   containers.lan.quietlife.net.
+          links           IN  CNAME   containers.lan.quietlife.net.
         '';
       };
 


### PR DESCRIPTION
Add linkding bookmark manager at `links.lan.quietlife.net` for self-hosted bookmark management (migrated from Pinboard).

Changes
- Add linkding service to Docker Compose stack with Traefik routing and SQLite storage
- Add OpenBao fetch for superuser credentials (`kv/infra/linkding/superuser`)
- Add `links` CNAME to NSD zone on dns1
- Update services and OpenBao secrets docs

Deployment
1. Secret already stored in OpenBao
2. Deploy DNS: `make nix-deploy-host HOST=dns1 TARGET=10.10.15.15`
3. Deploy containers: `make ansible-containers`
