### PR TITLE
Add photos.chriswage.com CNAME record

### DIFF
--- a/tofu/cloudflare.tf
+++ b/tofu/cloudflare.tf
@@ -15,3 +15,12 @@ data "cloudflare_zone" "quietlife" {
 data "cloudflare_zone" "chriswage" {
   name = "chriswage.com"
 }
+
+# photos.chriswage.com -> GitHub Pages
+resource "cloudflare_record" "photos_chriswage" {
+  zone_id = data.cloudflare_zone.chriswage.zone_id
+  name    = "photos"
+  type    = "CNAME"
+  content = "cwage.github.io"
+  proxied = true
+}


### PR DESCRIPTION
## Summary
- Adds a Cloudflare-proxied CNAME record pointing `photos.chriswage.com` to `cwage.github.io`
- Preparation for moving the chriswage.com photo site to a subdomain

## Test plan
- [x] `make tofu-plan` shows 1 to add, 0 to change, 0 to destroy
- [x] `make tofu-apply` completed successfully
- [x] `dig photos.chriswage.com` resolves to Cloudflare edge IPs (CNAME flattening confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)