### PR TITLE
Add Nix ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,9 @@ updates:
     directory: "/ansible"
     schedule:
       interval: "monthly"
+
+  # Nix flake input updates
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add Dependabot version updates for Nix flake inputs.

Changes
- Add `nix` package ecosystem to `.github/dependabot.yml` on weekly schedule
- Dependabot will monitor `flake.lock` and open PRs when nixpkgs (or any future flake inputs) have newer commits upstream

Test Plan
- Verify Dependabot picks up the new ecosystem on next scheduled run
- Confirm PRs appear for `flake.lock` updates
