### PR TITLE
Drop port 443 from felix sshd (brute-force mitigation)

### DIFF
--- a/ansible/inventories/host_vars/felix.yml
+++ b/ansible/inventories/host_vars/felix.yml
@@ -1,5 +1,8 @@
 # Host-specific configuration for felix (Linode VPS)
 
+# Minimal Linode Ubuntu image ships only python3, no /usr/bin/python
+ansible_python_interpreter: /usr/bin/python3
+
 # Static MOTD text
 motd_message: "Welcome to felix.quietlife.net! E-mail cwage@quietlife.net if you need help."
 

--- a/ansible/roles/system/defaults/main.yml
+++ b/ansible/roles/system/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 domain_name: quietlife.net
 ssh_ports:
-  - 443
   - 5344


### PR DESCRIPTION
Stop felix's sshd from listening on port 443, which was being brute-forced hard enough to disrupt legitimate connections on the other port.

## Context

felix (Linode VPS) was taking ~7 SSH brute-force attempts per second on port 443 from a single IP (`172.239.9.165`, 166,745 attempts in 24h). Because one sshd instance listens on both 443 and 5344, the shared `MaxStartups` bucket got exhausted — causing intermittent "Connection reset by peer / Exceeded MaxStartups" errors for legit scp/ssh on port 5344.

Port 443 was originally enabled for a friend tunneling through hostile networks (hotel wifi, etc.) and is no longer needed.

## Changes

- `ansible/roles/system/defaults/main.yml` — drop `443` from `ssh_ports`, leaving only `5344`. No group or host currently overrides the default to include 443, so felix is the only affected host. `turn_servers` already overrides to `[22, 5344]`.
- `ansible/inventories/host_vars/felix.yml` — pin `ansible_python_interpreter: /usr/bin/python3`. The minimal Linode Ubuntu image ships only python3, and ansible's `auto_silent` discovery was falling back to a nonexistent `/usr/bin/python`, failing every playbook at the first task. Unrelated to the 443 fix but had to be resolved to deploy it.

## Deploy

Already applied via `make ansible-felix`. Post-deploy verification:

- External probe: port 443 refuses connection, port 5344 serves `SSH-2.0-OpenSSH_9.6p1`.
- 0 `MaxStartups` throttle events in the 16h following deploy (vs. 113 in the 24h before).
- The specific attacker gave up at 05:43 Apr 16 and has not returned.

## Follow-ups (not in this PR)

Underlying exposure on port 5344 is unchanged. Worth a separate PR:

- `PerSourceMaxStartups 5` / `PerSourceNetBlockSize 24` — prevent a single IP from eating the whole MaxStartups budget.
- `PasswordAuthentication no` — key auth works everywhere; no reason to accept passwords.
- Add a `fail2ban` role.

## Test plan

- [x] `make ansible-felix-check` shows only sshd_config + ssh.socket drop-in changes
- [x] `make ansible-felix` applies cleanly
- [x] `nc -zv felix.quietlife.net 443` → refused
- [x] `nc -zv felix.quietlife.net 5344` → OpenSSH banner
- [x] `ssh felix` still works
- [x] No MaxStartups drops in journalctl post-deploy
