### PR TITLE
Add ntfy.sh notifications for scheduled job success/failure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
           "${nixpkgs}/nixos/modules/virtualisation/proxmox-image.nix"
           ./modules/base.nix
           ./modules/openbao-agent.nix
+          ./modules/ntfy-notify.nix
           ./hosts/openbao/configuration.nix
         ];
       };

--- a/hosts/openbao/configuration.nix
+++ b/hosts/openbao/configuration.nix
@@ -109,12 +109,21 @@
     options = [ "noatime" "_netdev" "nofail" ];
   };
 
+  homelab.ntfy = {
+    enable = true;
+    topic = "https://ntfy.sh/cwage-homelab-backup";
+  };
+
   systemd.services.openbao-backup = {
     description = "OpenBao Raft snapshot backup";
     path = with pkgs; [ openbao coreutils gnugrep findutils ];
     # Refuse to run if the NFS share isn't mounted — otherwise snapshots
     # would silently land on the root filesystem.
-    unitConfig.RequiresMountsFor = "/mnt/backups";
+    unitConfig = {
+      RequiresMountsFor = "/mnt/backups";
+      OnFailure = [ "notify-failure@%n.service" ];
+      OnSuccess = [ "notify-success@%n.service" ];
+    };
     serviceConfig = {
       Type = "oneshot";
       User = "root";

--- a/modules/ntfy-notify.nix
+++ b/modules/ntfy-notify.nix
@@ -14,19 +14,26 @@ let
     in pkgs.writeShellScript "ntfy-notify-${status}" ''
       set -u
       unit="''${1:-unknown}"
-      topic="${cfg.topic}"
+      topic=${lib.escapeShellArg cfg.topic}
       host="$(${pkgs.nettools}/bin/hostname)"
 
-      body=$(${pkgs.systemd}/bin/journalctl -u "$unit" -n 20 --no-pager 2>&1 \
-        | ${pkgs.coreutils}/bin/tr -d '[:cntrl:]' \
-        | ${pkgs.coreutils}/bin/head -c 4000 \
-        || ${pkgs.coreutils}/bin/echo "(no journal output)")
+      # Capture journal first so we can detect journalctl failures explicitly,
+      # then strip control chars (preserving \n and \t for readability) and
+      # cap to 4KB.
+      body="$(${pkgs.systemd}/bin/journalctl -u "$unit" -n 20 --no-pager 2>&1)" \
+        || body="(no journal output)"
+      body="$(${pkgs.coreutils}/bin/printf '%s' "$body" \
+        | ${pkgs.coreutils}/bin/tr -d '\000-\010\013-\037\177' \
+        | ${pkgs.coreutils}/bin/head -c 4000)"
 
+      # --data-raw avoids curl's @filename special-case for payloads that
+      # might start with @ (defense in depth — journal output is unlikely
+      # to start that way, but cheap to prevent).
       ${pkgs.curl}/bin/curl -sf -o /dev/null \
         -H "Priority: ${a.priority}" \
         -H "Title: Job ${a.verb} on $host: $unit" \
         -H "Tags: ${a.tag},$host" \
-        -d "$body" \
+        --data-raw "$body" \
         "$topic" || true
     '';
 
@@ -51,8 +58,9 @@ in
       example = "https://ntfy.sh/cwage-homelab-backup";
       description = ''
         Full URL to the ntfy.sh topic that notifications post to.
-        Treated as low-sensitivity: leak risk is unsolicited messages on the
-        topic, not data exposure. Rotate by changing this value.
+        Notifications include the last journal lines from the triggering
+        unit, so anyone who knows or guesses this URL can read those logs.
+        Pick a hard-to-guess topic name and rotate this value if it leaks.
       '';
     };
   };

--- a/modules/ntfy-notify.nix
+++ b/modules/ntfy-notify.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.homelab.ntfy;
+
+  # status: "failure" or "success" — controls priority/title/tags
+  mkNotifyScript = status:
+    let
+      attrs = {
+        failure = { priority = "urgent"; verb = "failed"; tag = "x"; };
+        success = { priority = "low"; verb = "ok"; tag = "white_check_mark"; };
+      };
+      a = attrs.${status};
+    in pkgs.writeShellScript "ntfy-notify-${status}" ''
+      set -u
+      unit="''${1:-unknown}"
+      topic="${cfg.topic}"
+      host="$(${pkgs.nettools}/bin/hostname)"
+
+      body=$(${pkgs.systemd}/bin/journalctl -u "$unit" -n 20 --no-pager 2>&1 \
+        | ${pkgs.coreutils}/bin/tr -d '[:cntrl:]' \
+        | ${pkgs.coreutils}/bin/head -c 4000 \
+        || ${pkgs.coreutils}/bin/echo "(no journal output)")
+
+      ${pkgs.curl}/bin/curl -sf -o /dev/null \
+        -H "Priority: ${a.priority}" \
+        -H "Title: Job ${a.verb} on $host: $unit" \
+        -H "Tags: ${a.tag},$host" \
+        -d "$body" \
+        "$topic" || true
+    '';
+
+  mkNotifyService = status: {
+    description = "ntfy.sh ${status} notification for %i";
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${mkNotifyScript status} %i";
+      ProtectSystem = "strict";
+      ProtectHome = true;
+      NoNewPrivileges = true;
+      PrivateTmp = true;
+    };
+  };
+in
+{
+  options.homelab.ntfy = {
+    enable = lib.mkEnableOption "ntfy.sh notifications for systemd units";
+
+    topic = lib.mkOption {
+      type = lib.types.str;
+      example = "https://ntfy.sh/cwage-homelab-backup";
+      description = ''
+        Full URL to the ntfy.sh topic that notifications post to.
+        Treated as low-sensitivity: leak risk is unsolicited messages on the
+        topic, not data exposure. Rotate by changing this value.
+      '';
+    };
+  };
+
+  # Defines two systemd template units. Wire either or both onto a unit:
+  #
+  #   systemd.services.foo.unitConfig = {
+  #     OnFailure = [ "notify-failure@%n.service" ];
+  #     OnSuccess = [ "notify-success@%n.service" ];
+  #   };
+  #
+  # `%n` in OnFailure/OnSuccess expands to the failing/finishing unit's full
+  # name, which becomes `%i` inside the template — used as the journalctl -u
+  # target and notification title.
+  config = lib.mkIf cfg.enable {
+    systemd.services."notify-failure@" = mkNotifyService "failure";
+    systemd.services."notify-success@" = mkNotifyService "success";
+  };
+}


### PR DESCRIPTION
Adds a small NixOS module that sends ntfy.sh notifications when a systemd unit fails (and, for now, when it succeeds). First consumer is bao2's `openbao-backup.service`.

Closes #221.

## Why

Motivated by the silent backup-token expiry discovered during the openbao migration (#218 / #219): the daily Raft snapshot cron on the old openbao VM had been failing for an unknown period because the script's backup token had expired, and the cron's non-zero exit went unnoticed. "Fail-safe by design" is fine until you actually need a recent backup.

## What's in the module

- `modules/ntfy-notify.nix` defines two systemd template units:
  - `notify-failure@.service` — priority `urgent`, tag `x`
  - `notify-success@.service` — priority `low`, tag `white_check_mark`
- Both pull the last 20 journal lines from the triggering unit and POST them to the configured topic with hostname in the title.
- Single config option: `homelab.ntfy.topic` (full URL). Reused with the existing backup ntfy topic — leak risk is unsolicited messages on the topic, not data exposure.

## Wired in

`hosts/openbao/configuration.nix` enables the module and adds:

```nix
unitConfig = {
  RequiresMountsFor = "/mnt/backups";
  OnFailure = [ "notify-failure@%n.service" ];
  OnSuccess = [ "notify-success@%n.service" ];
};
```

`%n` in OnFailure/OnSuccess expands to the failing/finishing unit's name and is passed to the template as `%i`.

## On notifying success

Keeping success notifications on for now to confirm scheduled jobs are actually firing — easy to drop the OnSuccess line later if it gets noisy. Without it, "no news" is ambiguous (good run vs. timer not firing at all).

## Test Plan

- [x] `nix eval .#nixosConfigurations.bao2.config.system.build.toplevel.drvPath` — flake evaluates clean
- [x] Deploy to bao2 via `make nix-deploy-host HOST=bao2 TARGET=10.10.15.16`
- [x] Manually trigger `systemctl start openbao-backup.service` on bao2 — success notification landed
- [ ] Wait one daily cycle (00:30) to confirm timer fires + notifies
- [ ] Eventually: induce a failure (e.g., temporarily revoke backup token) to confirm the failure path
