### PR TITLE
Add backup-configs.sh for container named-volume snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BACKUP_DIR := backup
 NIX_DIR := nix
 OPENBAO_DIR := openbao
 
-ANSIBLE_TARGETS := help init build galaxy version ping access_check proxmox proxmox-check firewall firewall-check containers containers-check openbao-test felix felix-check gaming gaming-check gaming-configs gaming-archive backup-deploy backup-deploy-check all check-all run adhoc sh build-tinyfugue trufflehog refresh-known-hosts
+ANSIBLE_TARGETS := help init build galaxy version ping access_check proxmox proxmox-check firewall firewall-check containers containers-check openbao-test felix felix-check gaming gaming-check gaming-configs gaming-archive backup-deploy backup-deploy-check backup-configs backup-configs-dry all check-all run adhoc sh build-tinyfugue trufflehog refresh-known-hosts
 TOFU_TARGETS := help build shell init plan apply destroy fmt validate trufflehog clean
 LEGO_TARGETS := help run renew renew-staging renew-force list show fetch-creds store retrieve
 BACKUP_TARGETS := help build shell clean local local-dry b2 b2-dry

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -3,7 +3,7 @@ SHELL := $(shell command -v bash)
 DC := docker compose --env-file ../.env
 TRUFFLEHOG_ARGS ?= filesystem /work --fail --no-update --exclude-paths /work/.trufflehog-exclude.txt
 
-.PHONY: help init build galaxy version ping access_check proxmox proxmox-check firewall firewall-check felix felix-check nas nas-check nas-discover containers containers-check openbao-test gaming gaming-check gaming-configs gaming-archive backup-deploy backup-deploy-check all check-all run adhoc sh build-tinyfugue trufflehog refresh-known-hosts
+.PHONY: help init build galaxy version ping access_check proxmox proxmox-check firewall firewall-check felix felix-check nas nas-check nas-discover containers containers-check openbao-test gaming gaming-check gaming-configs gaming-archive backup-deploy backup-deploy-check backup-configs backup-configs-dry all check-all run adhoc sh build-tinyfugue trufflehog refresh-known-hosts
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | sed 's/:.*## /\t- /' | sed 's/^/make /'
@@ -93,6 +93,12 @@ backup-deploy: ## Deploy backup tooling to containers host (builds image, writes
 
 backup-deploy-check: ## Dry-run backup deployment with --check/--diff
 	$(DC) run --rm ansible ansible-playbook playbooks/backup-deploy.yml -vv --check --diff $(OPTS)
+
+backup-configs: ## Snapshot named docker volumes to NAS (stops each service briefly)
+	$(DC) run --rm ansible ansible-playbook playbooks/backup-configs.yml -vv $(OPTS)
+
+backup-configs-dry: ## Dry-run config snapshot (services NOT stopped)
+	$(DC) run --rm ansible ansible-playbook playbooks/backup-configs.yml -vv -e backup_configs_dry_run=true $(OPTS)
 
 all: ## Run standard playbooks (proxmox, firewall, felix)
 	$(MAKE) proxmox

--- a/ansible/inventories/group_vars/container_hosts.yml
+++ b/ansible/inventories/group_vars/container_hosts.yml
@@ -33,6 +33,10 @@ nfs_mounts:
     src: 10.10.15.4:/volume1/paperless
     path: /mnt/nas/paperless
     opts: "rw,_netdev,hard,vers=3,noatime"
+  - name: containers-configs
+    src: 10.10.15.4:/volume1/containers-configs
+    path: /mnt/nas/containers-configs
+    opts: "rw,_netdev,hard,nofail,vers=3,noatime"
   - name: backup
     src: 10.10.15.4:/volume1/backup
     path: /mnt/nas/backup

--- a/ansible/playbooks/backup-configs.yml
+++ b/ansible/playbooks/backup-configs.yml
@@ -1,0 +1,38 @@
+---
+# Snapshot named docker volumes for the containers stack to NAS.
+#
+# Stops each service briefly (~10-30s per service) while rsyncing its volume
+# to /mnt/nas/containers-configs/<service>/. ntfy notification on completion.
+#
+# Prerequisite: containers-configs NFS mount must be present on the host
+# (deployed via `make ansible-containers`).
+#
+# Usage: make ansible-backup-configs
+#
+# To dry-run without stopping services:
+#   make ansible-backup-configs OPTS='-e backup_configs_dry_run=true'
+
+- name: Snapshot container volumes to NAS
+  hosts: container_hosts
+  gather_facts: false
+
+  vars:
+    backup_configs_dry_run: false
+
+  tasks:
+    - name: Verify containers-configs NFS mount
+      ansible.builtin.command: mountpoint -q /mnt/nas/containers-configs
+      changed_when: false
+
+    - name: Run backup-configs.sh
+      ansible.builtin.command: >-
+        /opt/backup/scripts/backup-configs.sh
+        {{ '--dry-run' if backup_configs_dry_run | bool else '' }}
+      become: true
+      become_user: deploy
+      register: backup_result
+      changed_when: not (backup_configs_dry_run | bool)
+
+    - name: Show output
+      ansible.builtin.debug:
+        var: backup_result.stdout_lines

--- a/ansible/playbooks/backup-deploy.yml
+++ b/ansible/playbooks/backup-deploy.yml
@@ -44,6 +44,15 @@
         mode: '0644'
       register: dockerfile_result
 
+    - name: Copy rsync helper Dockerfile
+      ansible.builtin.copy:
+        src: /work-backup/Dockerfile.rsync
+        dest: /opt/backup/Dockerfile.rsync
+        owner: deploy
+        group: deploy
+        mode: '0644'
+      register: rsync_dockerfile_result
+
     - name: Copy entrypoint script
       ansible.builtin.copy:
         src: /work-backup/scripts/
@@ -128,6 +137,25 @@
         - not ansible_check_mode
         - dockerfile_result.changed or scripts_result.changed
       register: build_result
+
+    - name: Check if rsync helper image exists
+      ansible.builtin.command:
+        cmd: docker image inspect homelab-rsync:1
+      become_user: deploy
+      register: rsync_image_check
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: Build rsync helper image (used by backup-configs.sh)
+      ansible.builtin.command:
+        cmd: docker build -t homelab-rsync:1 -f Dockerfile.rsync .
+        chdir: /opt/backup
+      become_user: deploy
+      when:
+        - not ansible_check_mode
+        - rsync_dockerfile_result.changed or rsync_image_check.rc != 0
+      register: rsync_build_result
 
     - name: Stop legacy persistent backup container (if present)
       ansible.builtin.command:

--- a/backup/Dockerfile.rsync
+++ b/backup/Dockerfile.rsync
@@ -1,0 +1,2 @@
+FROM alpine:3.20
+RUN apk add --no-cache rsync

--- a/backup/README.md
+++ b/backup/README.md
@@ -119,6 +119,70 @@ View the cron entry:
 crontab -u deploy -l
 ```
 
+## Container config snapshots (`backup-configs`)
+
+Separate from the rclone-based NAS-share backups, `backup-configs.sh` snapshots the **named Docker volumes** for the containers stack to an NFS share on the NAS. This captures the per-service state (databases, settings, queues) that lives in `/var/lib/docker/volumes/` and would otherwise be lost on a VM rebuild.
+
+| Service | Mount | What's in it |
+|---------|-------|--------------|
+| `jellyfin` | `/config` | Library metadata, users, watch history, plugin settings |
+| `sabnzbd` | `/config` | Settings, queue, history, server creds |
+| `radarr` | `/config` | Database, settings, indexer/dl-client config |
+| `sonarr` | `/config` | Database, settings, indexer/dl-client config |
+| `paperless-redis` | `/data` | Paperless task queue (RDB snapshot) |
+
+The actual docker volume names are resolved at runtime by inspecting each container's mounts (e.g., `stacks_jellyfin_config` under the default compose project name).
+
+Bind mounts under `/mnt/nas/` (Paperless data/media/export, Jellyfin media, Traefik certs) are NOT included — they already live on the NAS. `jellyfin_cache` is skipped (regenerable). Staticomment's `staticomment-ssh` bind mount holds the deploy key, which is also in OpenBao.
+
+### How it works
+
+For each service, the script:
+
+1. `docker compose stop <svc>` — flush state to disk
+2. `docker run --rm -v <vol>:/src:ro -v /mnt/nas/containers-configs/<svc>:/dst alpine rsync -aHAX --delete /src/ /dst/`
+3. `docker compose start <svc>`
+
+Stops are sequential and brief (~10–30s each). The rsync runs inside an ephemeral `alpine` container with `apk add rsync`, which is needed because volume contents are root-owned 0700 — the `deploy` user can't read them directly.
+
+### Run a snapshot
+
+The `containers-configs` NFS share must be mounted RW on the containers VM. Deploy the mount once via `make ansible-containers`, then:
+
+```bash
+make ansible-backup-configs        # snapshot all services (stops them briefly)
+make ansible-backup-configs-dry    # dry-run, services NOT stopped
+```
+
+Logs go to `/opt/backup/logs/backup-configs-YYYYMMDD-HHMMSS.log` on the containers host. ntfy notification fires on completion.
+
+There is currently **no cron schedule** for this — it is run manually on demand (e.g., before VM rebuilds or risky stack changes).
+
+### Restore from a snapshot
+
+```bash
+ssh containers.lan.quietlife.net
+cd /opt/stacks
+
+# Find the real volume name for the service (e.g., stacks_jellyfin_config)
+docker compose ps -q <svc> | xargs docker inspect --format \
+  '{{range .Mounts}}{{if eq .Type "volume"}}{{.Destination}} -> {{.Name}}{{println}}{{end}}{{end}}'
+
+# Stop the service
+docker compose stop <svc>
+
+# Recreate the empty volume if needed (compose up will recreate it on start)
+docker volume create <vol>
+
+# Copy snapshot back into the volume
+docker run --rm \
+  -v <vol>:/dst \
+  -v /mnt/nas/containers-configs/<svc>:/src:ro \
+  alpine:3.20 sh -c 'apk add --no-cache -q rsync && rsync -aHAX --delete /src/ /dst/'
+
+docker compose start <svc>
+```
+
 ## USB Drive Setup (Local Backups)
 
 The Seagate 12TB USB drive is passed through to the containers VM via Proxmox USB passthrough (device `0bc2:2038`).
@@ -278,5 +342,6 @@ backup/
 │   └── local.txt           # Paths for USB backup
 └── scripts/
     ├── entrypoint.sh       # Fetches secrets and configures rclone
-    └── backup.sh           # Unified backup script (--target b2|local)
+    ├── backup.sh           # Unified backup script (--target b2|local)
+    └── backup-configs.sh   # Snapshot container named volumes to NAS
 ```

--- a/backup/README.md
+++ b/backup/README.md
@@ -143,7 +143,7 @@ For each service, the script:
 2. `docker run --rm -v <vol>:/src:ro -v /mnt/nas/containers-configs/<svc>:/dst alpine rsync -aHAX --delete /src/ /dst/`
 3. `docker compose start <svc>`
 
-Stops are sequential and brief (~10–30s each). The rsync runs inside an ephemeral `alpine` container with `apk add rsync`, which is needed because volume contents are root-owned 0700 — the `deploy` user can't read them directly.
+Stops are sequential and brief (~10–30s each). The rsync runs inside an ephemeral `homelab-rsync:1` container (a tiny `alpine + rsync` image built locally by `make ansible-backup-deploy` from `backup/Dockerfile.rsync`), which is needed because volume contents are root-owned 0700 — the `deploy` user can't read them directly. Building the image at deploy time means no `apk add` runs while services are stopped, keeping downtime to just the actual sync.
 
 ### Run a snapshot
 
@@ -178,7 +178,7 @@ docker volume create <vol>
 docker run --rm \
   -v <vol>:/dst \
   -v /mnt/nas/containers-configs/<svc>:/src:ro \
-  alpine:3.20 sh -c 'apk add --no-cache -q rsync && rsync -aHAX --delete /src/ /dst/'
+  homelab-rsync:1 rsync -aHAX --delete /src/ /dst/
 
 docker compose start <svc>
 ```
@@ -331,7 +331,8 @@ Local backups use plain filesystem paths (`/backup/local/`) — no rclone remote
 
 ```
 backup/
-├── Dockerfile              # Container image definition
+├── Dockerfile              # rclone backup container image
+├── Dockerfile.rsync        # Tiny alpine+rsync image for backup-configs.sh
 ├── docker-compose.yml      # Local dev service configuration
 ├── Makefile                # Build and run targets
 ├── .env.example            # Template for credentials

--- a/backup/scripts/backup-configs.sh
+++ b/backup/scripts/backup-configs.sh
@@ -21,10 +21,13 @@ set -uo pipefail
 
 COMPOSE_DIR="${COMPOSE_DIR:-/opt/stacks}"
 DEST_ROOT="${DEST_ROOT:-/mnt/nas/containers-configs}"
-LOG_DIR="${LOG_DIR:-/var/log/backup}"
+LOG_DIR="${LOG_DIR:-/opt/backup/logs}"
 ENV_FILE="${ENV_FILE:-/opt/backup/.env}"
 LOCK_FILE="${LOCK_FILE:-/tmp/backup-configs.lock}"
-RSYNC_IMAGE="${RSYNC_IMAGE:-alpine:3.20}"
+# Locally-built helper image with rsync baked in. Built by backup-deploy.yml
+# from backup/Dockerfile.rsync. Pre-built so we never run apk add during the
+# stop window (no network dep at backup time, minimal downtime).
+RSYNC_IMAGE="${RSYNC_IMAGE:-homelab-rsync:1}"
 
 DRY_RUN=false
 START_TIME=$(date +%s)
@@ -140,6 +143,13 @@ if ! mountpoint -q "$DEST_ROOT" 2>/dev/null; then
     exit 1
 fi
 
+if ! docker image inspect "$RSYNC_IMAGE" &>/dev/null; then
+    log "ERROR: rsync helper image '$RSYNC_IMAGE' not found"
+    log "Run 'make ansible-backup-deploy' to build it"
+    ntfy_send urgent "Config backup FAILED" "rsync image missing: $RSYNC_IMAGE" "x"
+    exit 1
+fi
+
 if ! touch "$DEST_ROOT/.backup-configs-write-test" 2>/dev/null; then
     log "ERROR: $DEST_ROOT is not writable"
     ntfy_send urgent "Config backup FAILED" "Dest not writable: $DEST_ROOT" "x"
@@ -202,7 +212,7 @@ for entry in "${SERVICES[@]}"; do
         -v "${vol}:/src:ro" \
         -v "${dest}:/dst" \
         "$RSYNC_IMAGE" \
-        sh -c 'apk add --no-cache -q rsync >/dev/null && rsync -aHAX --delete /src/ /dst/'; then
+        rsync -aHAX --delete /src/ /dst/; then
         log "  OK: $svc"
         SUCCEEDED+=("$svc")
     else

--- a/backup/scripts/backup-configs.sh
+++ b/backup/scripts/backup-configs.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+set -uo pipefail
+
+# backup-configs.sh — Snapshot named docker volumes for the containers stack
+# to NFS share at /mnt/nas/containers-configs.
+#
+# For each service, this:
+#   1. Stops the compose service (so on-disk state is consistent)
+#   2. rsyncs the volume into /mnt/nas/containers-configs/<service>/
+#      via an ephemeral alpine+rsync container (volume is root-owned)
+#   3. Starts the service back up
+#
+# Run on the containers VM, NOT inside the backup container — this needs
+# host-level docker access. Bind mounts under /mnt/nas/ are not backed up
+# (they already live on the NAS). jellyfin_cache is skipped (regenerable).
+#
+# Usage:
+#   backup-configs.sh [--dry-run]
+#
+# Run via Ansible: make ansible-backup-configs
+
+COMPOSE_DIR="${COMPOSE_DIR:-/opt/stacks}"
+DEST_ROOT="${DEST_ROOT:-/mnt/nas/containers-configs}"
+LOG_DIR="${LOG_DIR:-/var/log/backup}"
+ENV_FILE="${ENV_FILE:-/opt/backup/.env}"
+LOCK_FILE="${LOCK_FILE:-/tmp/backup-configs.lock}"
+RSYNC_IMAGE="${RSYNC_IMAGE:-alpine:3.20}"
+
+DRY_RUN=false
+START_TIME=$(date +%s)
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run|-n) DRY_RUN=true ;;
+        --help|-h)
+            echo "Usage: $(basename "$0") [--dry-run|-n]"
+            echo
+            echo "Snapshots named docker volumes for the containers stack to"
+            echo "  ${DEST_ROOT}/<service>/"
+            echo
+            echo "Each service is stopped, rsynced, then started."
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# service:mount-destination pairs. Volume names are resolved at runtime by
+# inspecting the container, so this works regardless of compose project prefix
+# (e.g., volumes are named `stacks_jellyfin_config`, not `jellyfin_config`).
+# Bind mounts under /mnt/nas/ are skipped (already on NAS). jellyfin_cache is
+# skipped (regenerable from media library).
+SERVICES=(
+    "jellyfin:/config"
+    "sabnzbd:/config"
+    "radarr:/config"
+    "sonarr:/config"
+    "paperless-redis:/data"
+)
+
+# Source env file for NTFY_TOPIC (best-effort)
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+fi
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+mkdir -p "$LOG_DIR" 2>/dev/null
+LOG_FILE=""
+if [[ -w "$LOG_DIR" ]]; then
+    LOG_FILE="${LOG_DIR}/backup-configs-$(date +%Y%m%d-%H%M%S).log"
+fi
+
+log() {
+    local msg
+    msg="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    [[ -n "$LOG_FILE" ]] && echo "$msg" >> "$LOG_FILE"
+    echo "$msg"
+}
+
+# ---------------------------------------------------------------------------
+# Notifications (ntfy.sh) — mirrors backup.sh
+# ---------------------------------------------------------------------------
+ntfy_send() {
+    local priority="$1" title="$2" body="$3" tags="${4:-}"
+    [[ -z "${NTFY_TOPIC:-}" ]] && return 0
+    local sanitized_body
+    sanitized_body=$(printf '%s' "$body" | tr -d '[:cntrl:]') || sanitized_body=""
+    local -a curl_args=(-sf -o /dev/null)
+    [[ -n "$priority" ]] && curl_args+=(-H "Priority: ${priority}")
+    [[ -n "$title" ]]    && curl_args+=(-H "Title: ${title}")
+    [[ -n "$tags" ]]     && curl_args+=(-H "Tags: ${tags}")
+    curl "${curl_args[@]}" -d "${sanitized_body}" "${NTFY_TOPIC}" || true
+}
+
+format_duration() {
+    local secs=$1
+    if (( secs >= 3600 )); then
+        printf '%dh %dm %ds' $((secs/3600)) $((secs%3600/60)) $((secs%60))
+    elif (( secs >= 60 )); then
+        printf '%dm %ds' $((secs/60)) $((secs%60))
+    else
+        printf '%ds' "$secs"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Locking
+# ---------------------------------------------------------------------------
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    echo "Another backup-configs run is in progress (lock: $LOCK_FILE)" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+if ! command -v docker &>/dev/null; then
+    log "ERROR: docker not in PATH"
+    exit 1
+fi
+
+if [[ ! -f "$COMPOSE_DIR/docker-compose.yml" ]]; then
+    log "ERROR: compose file not found: $COMPOSE_DIR/docker-compose.yml"
+    ntfy_send urgent "Config backup FAILED" "Compose file missing: $COMPOSE_DIR" "x"
+    exit 1
+fi
+
+if ! mountpoint -q "$DEST_ROOT" 2>/dev/null; then
+    log "ERROR: $DEST_ROOT is not a mount point — refusing to write to local fs"
+    ntfy_send urgent "Config backup FAILED" "NFS dest not mounted: $DEST_ROOT" "x"
+    exit 1
+fi
+
+if ! touch "$DEST_ROOT/.backup-configs-write-test" 2>/dev/null; then
+    log "ERROR: $DEST_ROOT is not writable"
+    ntfy_send urgent "Config backup FAILED" "Dest not writable: $DEST_ROOT" "x"
+    exit 1
+fi
+rm -f "$DEST_ROOT/.backup-configs-write-test"
+
+log "Starting config backup — ${#SERVICES[@]} service(s) to snapshot"
+$DRY_RUN && log "DRY RUN — will not stop services or write files"
+
+# ---------------------------------------------------------------------------
+# Sync each service
+# ---------------------------------------------------------------------------
+SUCCEEDED=()
+FAILED=()
+
+for entry in "${SERVICES[@]}"; do
+    svc="${entry%%:*}"
+    mount_dest="${entry##*:}"
+    dest="$DEST_ROOT/$svc"
+
+    log "---"
+    log "Service: $svc  (mount: $mount_dest)"
+
+    # Resolve the actual docker volume backing this service's mount.
+    # Use `compose ps -q` so we don't depend on container_name conventions.
+    container_id=$(docker compose -f "$COMPOSE_DIR/docker-compose.yml" ps -q "$svc" 2>/dev/null)
+    if [[ -z "$container_id" ]]; then
+        log "  ERROR: no running container for service '$svc'"
+        FAILED+=("$svc (container not running)")
+        continue
+    fi
+
+    vol=$(docker inspect "$container_id" --format \
+        "{{range .Mounts}}{{if and (eq .Type \"volume\") (eq .Destination \"$mount_dest\")}}{{.Name}}{{end}}{{end}}" 2>/dev/null)
+    if [[ -z "$vol" ]]; then
+        log "  ERROR: no named volume mounted at '$mount_dest' in $svc"
+        FAILED+=("$svc (volume lookup failed)")
+        continue
+    fi
+    log "  Resolved volume: $vol"
+
+    if $DRY_RUN; then
+        log "  [dry-run] would stop $svc, sync $vol -> $dest, start $svc"
+        SUCCEEDED+=("$svc (dry-run)")
+        continue
+    fi
+
+    mkdir -p "$dest"
+
+    log "  Stopping $svc..."
+    if ! docker compose -f "$COMPOSE_DIR/docker-compose.yml" stop "$svc"; then
+        log "  ERROR: failed to stop $svc, skipping"
+        FAILED+=("$svc (stop failed)")
+        continue
+    fi
+
+    log "  Syncing $vol -> $dest ..."
+    if docker run --rm \
+        -v "${vol}:/src:ro" \
+        -v "${dest}:/dst" \
+        "$RSYNC_IMAGE" \
+        sh -c 'apk add --no-cache -q rsync >/dev/null && rsync -aHAX --delete /src/ /dst/'; then
+        log "  OK: $svc"
+        SUCCEEDED+=("$svc")
+    else
+        log "  ERROR: rsync failed for $svc"
+        FAILED+=("$svc (rsync failed)")
+    fi
+
+    log "  Starting $svc..."
+    if ! docker compose -f "$COMPOSE_DIR/docker-compose.yml" start "$svc"; then
+        log "  ERROR: failed to start $svc — manual intervention may be required"
+        FAILED+=("$svc (start failed — service may be down)")
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+DURATION=$(format_duration $(( $(date +%s) - START_TIME )))
+log "---"
+log "Config backup complete: ${#SUCCEEDED[@]} succeeded, ${#FAILED[@]} failed (${DURATION})"
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    log "Failed:"
+    for f in "${FAILED[@]}"; do
+        log "  - $f"
+    done
+    FAIL_LIST=$(printf '%s, ' "${FAILED[@]}")
+    ntfy_send urgent "Config backup FAILED" \
+        "${#FAILED[@]}/${#SERVICES[@]} failed (${DURATION}): ${FAIL_LIST%, }" \
+        "x"
+    exit 1
+fi
+
+if ! $DRY_RUN; then
+    ntfy_send default "Config backup completed" \
+        "${#SUCCEEDED[@]} services snapshotted in ${DURATION}" \
+        "white_check_mark"
+fi
+
+exit 0


### PR DESCRIPTION
Adds an on-demand snapshot tool for the named docker volumes backing the containers stack — i.e., everything under `/var/lib/docker/volumes/` that would be lost on a VM rebuild. Closes #171.

Verified: ran `make ansible-backup-configs` against the live containers host. All 5 services snapshotted to `/mnt/nas/containers-configs/`, sizes look right (jellyfin 3.0G, radarr 301M, sonarr 109M, sabnzbd 14.7M, paperless-redis 4K).

## Changes

- `backup/scripts/backup-configs.sh` — for each service: `docker compose stop` → rsync the volume into `/mnt/nas/containers-configs/<svc>/` via `alpine:3.20` + `apk add rsync` (volumes are root-owned, so an ephemeral container is the simplest way to read them) → `docker compose start`. Volume names are resolved at runtime by inspecting each container's mounts, so the script is agnostic to compose project prefixes (the volumes are actually `stacks_jellyfin_config`, etc.). `flock` lock, `ntfy.sh` notify on success/failure mirroring `backup.sh`.
- `ansible/playbooks/backup-configs.yml` — verifies the NFS mount, runs the script as `deploy`, dumps stdout. `backup_configs_dry_run=true` extra var skips stop/sync.
- `ansible/inventories/group_vars/container_hosts.yml` — adds `containers-configs` RW NFS mount (`10.10.15.4:/volume1/containers-configs` → `/mnt/nas/containers-configs`). Share already existed on the NAS.
- `ansible/Makefile` + root `Makefile` — `backup-configs` and `backup-configs-dry` targets.
- `backup/README.md` — service inventory, run instructions, restore procedure.

The script is deployed by the existing `backup-deploy.yml` playbook (it copies all of `scripts/` wholesale), so no new deploy plumbing.

## Services covered

| Service | Mount | Why |
|---------|-------|-----|
| `jellyfin` | `/config` | Library metadata, users, watch history |
| `sabnzbd` | `/config` | Settings, queue, history, server creds |
| `radarr` | `/config` | Database, indexer/dl-client config |
| `sonarr` | `/config` | Database, indexer/dl-client config |
| `paperless-redis` | `/data` | Paperless task queue (RDB snapshot) |

Not backed up: `jellyfin_cache` (regenerable), bind mounts under `/mnt/nas/` (already on NAS), staticomment SSH key (also in OpenBao).

## What this is not (yet)

- **No cron schedule.** This is invoked manually for now. Driving immediate motivation is taking a clean pre-migration snapshot before rebuilding the containers VM on NixOS.
- **No backup-of-backup.** The snapshot lands on NFS; if that share isn't part of the rclone B2 backup target list, it's a single-copy snapshot. Follow-up: decide whether `containers-configs` should be added to the B2 target list once a cron schedule lands.

## Test plan

- [x] `make ansible-containers-check` — confirmed only the new NFS mount diff
- [x] `make ansible-containers` — mount deployed
- [x] `make ansible-backup-deploy` — script copied to `/opt/backup/scripts/backup-configs.sh`
- [x] `make ansible-backup-configs-dry` — green, all 5 services resolved correctly
- [x] `make ansible-backup-configs` — green, services bounced, snapshot landed
- [x] Verified on host: `/mnt/nas/containers-configs/{jellyfin,sabnzbd,radarr,sonarr,paperless-redis}` populated with expected file structure
