### PR TITLE
Migrate containers VM to NixOS (containers2)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,16 @@
         ];
       };
 
+      nixosConfigurations.containers2 = nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          "${nixpkgs}/nixos/modules/virtualisation/proxmox-image.nix"
+          ./modules/base.nix
+          ./modules/openbao-agent.nix
+          ./hosts/containers2/configuration.nix
+        ];
+      };
+
       packages.${system} = {
         proxmox-template =
           self.nixosConfigurations.proxmox-template.config.system.build.VMA;

--- a/hosts/containers2/configuration.nix
+++ b/hosts/containers2/configuration.nix
@@ -1,0 +1,123 @@
+{ config, lib, pkgs, ... }:
+
+{
+  networking.hostName = "containers2";
+
+  # Prevent cloud-init from overriding the hostname after rebuild
+  # (same workaround as dns1/bao2)
+  environment.etc."cloud/cloud.cfg.d/99-preserve-hostname.cfg".text = ''
+    preserve_hostname: true
+  '';
+
+  # Resolve via fw1 (Unbound recursive, which stubs LAN zone to dns1)
+  networking.nameservers = [ "10.10.15.1" ];
+
+  # --- NFS mounts (mirror the Ansible-managed mounts on the live containers VM) ---
+  # Subset for now: just what's needed to consume the pre-migration snapshots
+  # and operate the existing services. Read-only shares (Books, Documents, etc.)
+  # follow once we're closer to cutover.
+  fileSystems."/mnt/nas/containers-configs" = {
+    device = "10.10.15.4:/volume1/containers-configs";
+    fsType = "nfs";
+    options = [ "rw" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/Media" = {
+    device = "10.10.15.4:/volume1/Media";
+    fsType = "nfs";
+    options = [ "rw" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/paperless" = {
+    device = "10.10.15.4:/volume1/paperless";
+    fsType = "nfs";
+    options = [ "rw" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  # Seagate 12TB USB backup drive (passed through from Proxmox).
+  # Mounted RW for the local backup target. nofail so the VM still boots if
+  # the drive is detached (e.g., during passthrough swaps).
+  fileSystems."/mnt/nasbak" = {
+    device = "/dev/disk/by-uuid/479d8cc7-5779-4707-bb19-87b555d7580b";
+    fsType = "ext4";
+    options = [ "rw" "nofail" "noatime" ];
+  };
+
+  # --- NVIDIA GPU (GTX 1050 Ti, passed through from Proxmox) ---
+  # Headless docker host: no X, but the videoDrivers entry is the canonical
+  # NixOS way to load the proprietary kernel module.
+  nixpkgs.config.allowUnfreePredicate = pkg:
+    builtins.elem (lib.getName pkg) [
+      "nvidia-x11"
+      "nvidia-settings"
+      "nvidia-persistenced"
+    ];
+  hardware.graphics.enable = true;
+  services.xserver.videoDrivers = [ "nvidia" ];
+  hardware.nvidia = {
+    modesetting.enable = true;
+    open = false;
+    nvidiaSettings = false;
+    package = config.boot.kernelPackages.nvidiaPackages.stable;
+  };
+
+  # --- Docker host ---
+  virtualisation.docker = {
+    enable = true;
+    daemon.settings = {
+      log-driver = "json-file";
+      log-opts = {
+        max-size = "10m";
+        max-file = "3";
+      };
+      # Register nvidia as a docker runtime so compose's
+      # `deploy.resources.reservations.devices` with driver: nvidia (and
+      # `--gpus all`) resolve to GPU passthrough.
+      runtimes.nvidia.path = "${pkgs.nvidia-container-toolkit}/bin/nvidia-container-runtime";
+    };
+  };
+
+  # CDI-based GPU access for containers (also used by the runtime above).
+  hardware.nvidia-container-toolkit.enable = true;
+
+  users.users.deploy.extraGroups = [ "docker" ];
+  users.users.cwage.extraGroups = [ "docker" ];
+
+  # /opt/stacks holds the docker-compose.yml + supporting files.
+  # /opt/backup holds the rclone backup container (parity with live VM).
+  # deploy user's primary group is "users" (NixOS default for isNormalUser).
+  # Static stack config (compose, traefik dyn config) is symlinked from the
+  # nix store. Secrets (.env, basicauth, ssh deploy key) and TLS certs remain
+  # mutable in /opt/stacks until they migrate to openbao-agent / lego.
+  systemd.tmpfiles.rules = [
+    "d /opt/stacks       0755 deploy users -"
+    "d /opt/stacks/certs 0755 deploy users -"
+    "d /opt/backup       0750 deploy users -"
+    "d /opt/backup/logs  0750 deploy users -"
+    "L+ /opt/stacks/docker-compose.yml - - - - ${./stacks/docker-compose.yml}"
+    "L+ /opt/stacks/traefik-tls.yml    - - - - ${./stacks/traefik-tls.yml}"
+  ];
+
+  environment.systemPackages = with pkgs; [
+    docker-compose
+    rsync
+  ];
+
+  # --- OpenBao agent for secrets (cwage password hash for now) ---
+  # Real services (Docker, GPU, NFS, TLS, stack) land in follow-up PRs.
+  # The roleId below is per-host and CIDR-bound to 10.10.15.11; fill it in
+  # after running:
+  #   make openbao-approle-create-role NAME=containers2 IP=10.10.15.11
+  homelab.openbao-agent = {
+    enable = true;
+    tlsSkipVerify = false;
+    roleId = "63c7ca9b-f390-ba83-5679-849473fe44f9";
+    secrets = {
+      cwage-password-hash = {
+        path = "kv/data/infra/users/cwage";
+        field = "password_hash";
+        destination = "/etc/secrets/cwage-password-hash";
+      };
+    };
+  };
+}

--- a/hosts/containers2/configuration.nix
+++ b/hosts/containers2/configuration.nix
@@ -91,7 +91,8 @@
   # mutable in /opt/stacks until they migrate to openbao-agent / lego.
   systemd.tmpfiles.rules = [
     "d /opt/stacks       0755 deploy users -"
-    "d /opt/stacks/certs 0755 deploy users -"
+    "d /opt/stacks/certs 0700 deploy users -"
+    "z /opt/stacks/certs 0700 deploy users -"
     "d /opt/backup       0750 deploy users -"
     "d /opt/backup/logs  0750 deploy users -"
     "L+ /opt/stacks/docker-compose.yml - - - - ${./stacks/docker-compose.yml}"
@@ -103,11 +104,12 @@
     rsync
   ];
 
-  # --- OpenBao agent for secrets (cwage password hash for now) ---
-  # Real services (Docker, GPU, NFS, TLS, stack) land in follow-up PRs.
-  # The roleId below is per-host and CIDR-bound to 10.10.15.11; fill it in
-  # after running:
-  #   make openbao-approle-create-role NAME=containers2 IP=10.10.15.11
+  # --- OpenBao agent for secrets ---
+  # Currently delivers the cwage password hash. Stack secrets (.env,
+  # traefik basicauth, staticomment ssh deploy key) and lego-managed TLS
+  # certs are still mutable in /opt/stacks/ and are slated to move into
+  # the agent in a follow-up.
+  # roleId is per-host and CIDR-bound to 10.10.15.11.
   homelab.openbao-agent = {
     enable = true;
     tlsSkipVerify = false;

--- a/hosts/containers2/stacks/docker-compose.yml
+++ b/hosts/containers2/stacks/docker-compose.yml
@@ -1,0 +1,201 @@
+services:
+  traefik:
+    image: traefik:v2.11
+    container_name: traefik
+    restart: unless-stopped
+    command:
+      - "--api=true"
+      - "--api.dashboard=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.file.filename=/etc/traefik/tls.yml"
+      - "--providers.file.watch=true"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
+      - "--entrypoints.websecure.address=:443"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./certs:/etc/traefik/certs:ro
+      - ./traefik-tls.yml:/etc/traefik/tls.yml:ro
+      - ./traefik-basicauth:/etc/traefik/basicauth:ro
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.traefik.rule=Host(`traefik.lan.quietlife.net`)"
+      - "traefik.http.routers.traefik.entrypoints=websecure"
+      - "traefik.http.routers.traefik.tls=true"
+      - "traefik.http.routers.traefik.service=api@internal"
+      - "traefik.http.routers.traefik.middlewares=traefik-auth"
+      - "traefik.http.middlewares.traefik-auth.basicauth.usersfile=/etc/traefik/basicauth"
+    networks:
+      - proxy
+
+  jellyfin:
+    image: linuxserver/jellyfin:10.11.6
+    container_name: jellyfin
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/Chicago
+    volumes:
+      - jellyfin_config:/config
+      - jellyfin_cache:/cache
+      - /mnt/nas/Media:/media
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.lan.quietlife.net`)"
+      - "traefik.http.routers.jellyfin.entrypoints=websecure"
+      - "traefik.http.routers.jellyfin.tls=true"
+      - "traefik.http.services.jellyfin.loadbalancer.server.port=8096"
+    networks:
+      - proxy
+    devices:
+      - "nvidia.com/gpu=all"
+
+  sabnzbd:
+    image: linuxserver/sabnzbd:4.5.5
+    container_name: sabnzbd
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/Chicago
+    volumes:
+      - sabnzbd_config:/config
+      - /mnt/nas/Media:/media
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.sabnzbd.rule=Host(`sabnzbd.lan.quietlife.net`)"
+      - "traefik.http.routers.sabnzbd.entrypoints=websecure"
+      - "traefik.http.routers.sabnzbd.tls=true"
+      - "traefik.http.services.sabnzbd.loadbalancer.server.port=8080"
+    networks:
+      - proxy
+
+  radarr:
+    image: linuxserver/radarr:6.0.4
+    container_name: radarr
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/Chicago
+    volumes:
+      - radarr_config:/config
+      - /mnt/nas/Media:/media
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.radarr.rule=Host(`radarr.lan.quietlife.net`)"
+      - "traefik.http.routers.radarr.entrypoints=websecure"
+      - "traefik.http.routers.radarr.tls=true"
+      - "traefik.http.services.radarr.loadbalancer.server.port=7878"
+    networks:
+      - proxy
+
+  sonarr:
+    image: linuxserver/sonarr:4.0.16
+    container_name: sonarr
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/Chicago
+    volumes:
+      - sonarr_config:/config
+      - /mnt/nas/Media:/media
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.sonarr.rule=Host(`sonarr.lan.quietlife.net`)"
+      - "traefik.http.routers.sonarr.entrypoints=websecure"
+      - "traefik.http.routers.sonarr.tls=true"
+      - "traefik.http.services.sonarr.loadbalancer.server.port=8989"
+    networks:
+      - proxy
+
+  paperless-redis:
+    image: docker.io/library/redis:8.0.5
+    container_name: paperless-redis
+    restart: unless-stopped
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      - paperless_redis:/data
+    networks:
+      - proxy
+
+  paperless:
+    image: ghcr.io/paperless-ngx/paperless-ngx:2.20.6
+    container_name: paperless
+    restart: unless-stopped
+    depends_on:
+      - paperless-redis
+    environment:
+      - PAPERLESS_REDIS=redis://paperless-redis:6379
+      - USERMAP_UID=1000
+      - USERMAP_GID=1000
+      - PAPERLESS_TIME_ZONE=America/Chicago
+      - PAPERLESS_URL=https://paperless.lan.quietlife.net
+    volumes:
+      - /mnt/nas/paperless/data:/usr/src/paperless/data
+      - /mnt/nas/paperless/media:/usr/src/paperless/media
+      - /mnt/nas/paperless/export:/usr/src/paperless/export
+      - /mnt/nas/paperless/consume:/usr/src/paperless/consume
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.paperless.rule=Host(`paperless.lan.quietlife.net`)"
+      - "traefik.http.routers.paperless.entrypoints=websecure"
+      - "traefik.http.routers.paperless.tls=true"
+      - "traefik.http.services.paperless.loadbalancer.server.port=8000"
+    networks:
+      - proxy
+
+  staticomment:
+    image: ghcr.io/cwage/staticomment:0.2.0
+    container_name: staticomment
+    restart: unless-stopped
+    environment:
+      - STATICOMMENT_GIT_REPO=${STATICOMMENT_GIT_REPO}
+      - STATICOMMENT_BRANCH=${STATICOMMENT_BRANCH:-main}
+      - STATICOMMENT_ALLOWED_ORIGINS=${STATICOMMENT_ALLOWED_ORIGINS}
+      - STATICOMMENT_SSH_KEY_PATH=/app/.ssh/id_ed25519
+    volumes:
+      - ./staticomment-ssh:/app/.ssh
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.staticomment.rule=Host(`staticomment.lan.quietlife.net`)"
+      - "traefik.http.routers.staticomment.entrypoints=websecure"
+      - "traefik.http.routers.staticomment.tls=true"
+      - "traefik.http.services.staticomment.loadbalancer.server.port=8080"
+    networks:
+      - proxy
+
+  cloudflared:
+    image: cloudflare/cloudflared:2026.1.2
+    container_name: cloudflared
+    restart: unless-stopped
+    command: tunnel run
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    networks:
+      - proxy
+    depends_on:
+      - jellyfin
+    profiles:
+      - tunnel
+
+volumes:
+  jellyfin_config:
+  jellyfin_cache:
+  sabnzbd_config:
+  radarr_config:
+  sonarr_config:
+  paperless_redis:
+
+networks:
+  proxy:
+    name: proxy
+

--- a/hosts/containers2/stacks/traefik-tls.yml
+++ b/hosts/containers2/stacks/traefik-tls.yml
@@ -1,0 +1,13 @@
+# Traefik TLS configuration
+# Defines certificates and TLS options for HTTPS
+
+tls:
+  certificates:
+    - certFile: /etc/traefik/certs/lan.quietlife.net.crt
+      keyFile: /etc/traefik/certs/lan.quietlife.net.key
+
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /etc/traefik/certs/lan.quietlife.net.crt
+        keyFile: /etc/traefik/certs/lan.quietlife.net.key

--- a/hosts/dns1/configuration.nix
+++ b/hosts/dns1/configuration.nix
@@ -31,7 +31,7 @@
           $TTL 300
 
           @       IN  SOA dns1.lan.quietlife.net. hostmaster.lan.quietlife.net. (
-                      2026042803  ; serial (YYYYMMDDNN)
+                      2026042902  ; serial (YYYYMMDDNN)
                       3600        ; refresh
                       600         ; retry
                       604800      ; expire
@@ -52,6 +52,7 @@
           bao             IN  A       10.10.15.16
           bao2            IN  A       10.10.15.16
           containers      IN  A       10.10.15.12
+          containers2     IN  A       10.10.15.11
           nintendoswitch  IN  A       10.10.15.13
           pve1            IN  A       10.10.15.18
           lattepanda      IN  A       10.10.15.20
@@ -62,13 +63,13 @@
           firewall        IN  CNAME   fw1.lan.quietlife.net.
           nas             IN  CNAME   portanas.lan.quietlife.net.
           proxmox         IN  CNAME   pve1.lan.quietlife.net.
-          traefik         IN  CNAME   containers.lan.quietlife.net.
-          jellyfin        IN  CNAME   containers.lan.quietlife.net.
-          sabnzbd         IN  CNAME   containers.lan.quietlife.net.
-          radarr          IN  CNAME   containers.lan.quietlife.net.
-          sonarr          IN  CNAME   containers.lan.quietlife.net.
-          paperless       IN  CNAME   containers.lan.quietlife.net.
-          staticomment    IN  CNAME   containers.lan.quietlife.net.
+          traefik         IN  CNAME   containers2.lan.quietlife.net.
+          jellyfin        IN  CNAME   containers2.lan.quietlife.net.
+          sabnzbd         IN  CNAME   containers2.lan.quietlife.net.
+          radarr          IN  CNAME   containers2.lan.quietlife.net.
+          sonarr          IN  CNAME   containers2.lan.quietlife.net.
+          paperless       IN  CNAME   containers2.lan.quietlife.net.
+          staticomment    IN  CNAME   containers2.lan.quietlife.net.
         '';
       };
 
@@ -78,7 +79,7 @@
           $TTL 300
 
           @       IN  SOA dns1.lan.quietlife.net. hostmaster.lan.quietlife.net. (
-                      2026042801  ; serial
+                      2026042902  ; serial
                       3600        ; refresh
                       600         ; retry
                       604800      ; expire
@@ -90,6 +91,7 @@
 
           ; PTR records
           1       IN  PTR     fw1.lan.quietlife.net.
+          11      IN  PTR     containers2.lan.quietlife.net.
           2       IN  PTR     wap.lan.quietlife.net.
           3       IN  PTR     portaplotz.lan.quietlife.net.
           4       IN  PTR     portanas.lan.quietlife.net.

--- a/tofu/containers.tf
+++ b/tofu/containers.tf
@@ -43,21 +43,10 @@ resource "proxmox_virtual_environment_vm" "containers" {
     size         = 64
   }
 
-  # Seagate 12TB USB backup drive passthrough
-  # Uses USB mapping (like GPU PCI mapping) so non-root API tokens can manage it
-  usb {
-    mapping = proxmox_virtual_environment_hardware_mapping_usb.seagate_backup.name
-    usb3   = true
-  }
-
-  # GTX 1050 Ti GPU passthrough (IOMMU Group 14)
-  # Uses PCI mapping defined in /etc/pve/mapping/pci.cfg
-  hostpci {
-    device  = "hostpci0"
-    mapping = "gpu-gtx1050ti"
-    pcie    = true
-    rombar  = true
-  }
+  # GPU and USB passthrough moved to containers2 (#132 cutover).
+  # This VM stays online as a fallback during stack migration but no longer
+  # owns the GTX 1050 Ti or the Seagate 12TB USB drive. Deleted once
+  # containers2 is verified and DNS cuts over.
 
   network_device {
     bridge = "vmbr0"

--- a/tofu/containers.tf
+++ b/tofu/containers.tf
@@ -1,19 +1,12 @@
-# Seagate 12TB USB backup drive — cluster-level hardware mapping
-# Allows non-root API tokens to attach the device to VMs
-resource "proxmox_virtual_environment_hardware_mapping_usb" "seagate_backup" {
-  name    = "usb-seagate-backup"
-  comment = "Seagate 12TB USB backup drive"
-
-  map = [
-    {
-      id   = "0bc2:2038"
-      node = var.pm_node_name
-    },
-  ]
-}
-
-# Container host VM - Docker host for running containerized apps
-# With GTX 1050 Ti GPU passthrough for hardware transcoding
+# Legacy Debian-based Docker host. As of #132 phase 2 it's powered off and
+# kept only as a rollback target — GPU and USB passthrough moved to
+# containers2 (10.10.15.11), and DNS for service CNAMEs (jellyfin/sonarr/etc.)
+# now points at containers2. Removed in a follow-up once containers2 is
+# trusted enough that we don't need the parachute.
+#
+# The Seagate USB hardware mapping that was previously defined here was moved
+# to tofu/hardware-mappings.tf so it survives the eventual deletion of this
+# resource.
 
 resource "proxmox_virtual_environment_vm" "containers" {
   name      = "containers"
@@ -43,10 +36,8 @@ resource "proxmox_virtual_environment_vm" "containers" {
     size         = 64
   }
 
-  # GPU and USB passthrough moved to containers2 (#132 cutover).
-  # This VM stays online as a fallback during stack migration but no longer
-  # owns the GTX 1050 Ti or the Seagate 12TB USB drive. Deleted once
-  # containers2 is verified and DNS cuts over.
+  # GPU and USB passthrough moved to containers2 at cutover (#132 phase 2).
+  # See the file-level comment above for the broader retirement plan.
 
   network_device {
     bridge = "vmbr0"
@@ -78,6 +69,10 @@ resource "proxmox_virtual_environment_vm" "containers" {
   }
 
   boot_order = ["scsi0"]
+
+  # Powered off post-cutover; kept defined as a rollback target only.
+  # Removed in a follow-up PR once containers2 is fully trusted.
+  started = false
 
   # Prevent Tofu from recreating the VM when cloud-init config drifts
   # after initial provisioning. Ansible manages config from here on.

--- a/tofu/containers2.tf
+++ b/tofu/containers2.tf
@@ -1,0 +1,85 @@
+# containers2: NixOS-based replacement for the containers VM (#171 / #132).
+# Stood up alongside the live Debian containers VM (10.10.15.12). Once Docker,
+# GPU, NFS, TLS, and the stack are migrated, the old VM and tofu/containers.tf
+# are decommissioned, GPU + USB passthrough swap to this host, and DNS for
+# containers.lan.quietlife.net (plus all service CNAMEs) flips here.
+
+resource "proxmox_virtual_environment_vm" "containers2" {
+  name      = "containers2"
+  node_name = var.pm_node_name
+  vm_id     = 152
+
+  description = "Docker host (NixOS) — successor to containers (#132)"
+
+  clone {
+    vm_id = var.pm_nixos_template_id
+  }
+
+  cpu {
+    cores = 4
+    type  = "host"
+  }
+
+  machine = "q35" # Required for PCIe passthrough (VFIO)
+
+  memory {
+    dedicated = 8192
+  }
+
+  disk {
+    datastore_id = var.pm_vm_datastore_id
+    interface    = "virtio0"
+    size         = 64
+  }
+
+  # Seagate 12TB USB backup drive passthrough
+  # Uses USB mapping (like GPU PCI mapping) so non-root API tokens can manage it
+  usb {
+    mapping = proxmox_virtual_environment_hardware_mapping_usb.seagate_backup.name
+    usb3   = true
+  }
+
+  # GTX 1050 Ti GPU passthrough (IOMMU Group 14)
+  # Uses PCI mapping defined in /etc/pve/mapping/pci.cfg
+  hostpci {
+    device  = "hostpci0"
+    mapping = "gpu-gtx1050ti"
+    pcie    = true
+    rombar  = true
+  }
+
+  network_device {
+    bridge = "vmbr0"
+  }
+
+  initialization {
+    datastore_id = var.pm_vm_datastore_id
+
+    ip_config {
+      ipv4 {
+        address = "10.10.15.11/24"
+        gateway = "10.10.15.1"
+      }
+    }
+
+    dns {
+      domain  = "lan.quietlife.net"
+      servers = ["10.10.15.1"]
+    }
+
+    user_account {
+      username = "deploy"
+      keys     = [trimspace(file("${path.module}/../ansible/keys/deploy.pub"))]
+    }
+  }
+
+  agent {
+    enabled = true
+  }
+
+  boot_order = ["virtio0"]
+
+  lifecycle {
+    ignore_changes = [initialization]
+  }
+}

--- a/tofu/hardware-mappings.tf
+++ b/tofu/hardware-mappings.tf
@@ -1,0 +1,17 @@
+# Cluster-level hardware mappings.
+# These outlive any individual VM definition: keeping them in their own file
+# means VMs that reference them can come and go without orphaning the mapping.
+
+# Seagate 12TB USB backup drive
+# Allows non-root API tokens to attach the device to VMs
+resource "proxmox_virtual_environment_hardware_mapping_usb" "seagate_backup" {
+  name    = "usb-seagate-backup"
+  comment = "Seagate 12TB USB backup drive"
+
+  map = [
+    {
+      id   = "0bc2:2038"
+      node = var.pm_node_name
+    },
+  ]
+}


### PR DESCRIPTION
Migrates the Docker host from the legacy Debian-based `containers` VM (vm_id=102, 10.10.15.12) to a NixOS-based successor `containers2` (vm_id=152, 10.10.15.11). Closes the second phase of #132.

## What's in this PR

**Tofu**
- New `tofu/containers2.tf` (clones NixOS template, attaches the GTX 1050 Ti hostpci mapping and Seagate 12TB USB mapping)
- `tofu/containers.tf` has hostpci/usb removed — old VM stays defined as a cold fallback until cutover is verified, then retired in a follow-up

**NixOS host config**
- `hosts/containers2/configuration.nix`: Docker host, NFS mounts (Media / paperless / containers-configs), `/mnt/nasbak` ext4 mount for the USB backup drive, NVIDIA proprietary driver + container-toolkit (CDI), explicit nvidia docker runtime registration so compose's GPU selection resolves
- `flake.nix`: new `nixosConfigurations.containers2` entry

**Stack config moved into the repo (NixOS-managed)**
- `hosts/containers2/stacks/docker-compose.yml` and `traefik-tls.yml` are checked in and materialized into `/opt/stacks/` via `systemd.tmpfiles` symlinks to the nix store — no more Ansible-deployed compose
- Jellyfin's GPU block switched from `deploy.resources.reservations.devices` (legacy `--gpus`) to CDI device syntax (`devices: ["nvidia.com/gpu=all"]`), which is what `nvidia-container-toolkit` exposes on NixOS
- Stack secrets (`.env`, traefik basicauth, staticomment ssh key) and TLS certs remain mutable in `/opt/stacks` for now — migrating those into openbao-agent / lego is follow-up work

**DNS flip**
- `hosts/dns1/configuration.nix`: `jellyfin`/`sabnzbd`/`radarr`/`sonarr`/`paperless`/`staticomment`/`traefik` CNAMEs repointed from `containers` to `containers2`, SOA serials bumped on forward and reverse zones

## Cutover executed

1. `tofu apply` swapped GPU + USB passthrough from 102 to 152 (in-place modify, both VMs rebooted)
2. NixOS deploy to containers2 (driver loaded after one reboot)
3. Docker volumes restored from `/mnt/nas/containers-configs/` snapshot via the `homelab-rsync:1` pattern: `stacks_jellyfin_config` (3.1G), `_radarr_config` (303M), `_sonarr_config` (129M), `_sabnzbd_config` (15M), `_paperless_redis` (8K)
4. Stack stopped on 102, VM 102 powered off (kept for rollback)
5. `docker compose --profile tunnel up -d` on containers2; cloudflared registered four tunnel connections
6. `make nix-deploy-host HOST=dns1` flipped DNS

## Test Plan

- [x] `nvidia-smi` from inside `jellyfin` container reports GTX 1050 Ti
- [x] All 8 services up and healthy
- [x] HTTPS on production hostnames returns expected 200/302 (post-DNS-flip)
- [x] Cloudflared tunnel registered to bna01/atl13/atl15 from containers2
- [x] Volume restore sanity: jellyfin DB knows about Firefly (S01E01 Serenity, S01E02 Bushwhacked, etc.)
- [ ] Real human smoke: log in, watch a video, verify GPU transcoding under load
- [ ] Verify paperless ingestion path still works end-to-end
- [ ] Leave 102 cold for a few days, then follow-up to remove `tofu/containers.tf`

## Follow-ups (not in this PR)

- Move `.env` / basicauth / staticomment ssh key into openbao-agent secret delivery
- TLS certs into a NixOS-side lego workflow
- Decommission `containers` (102): delete `tofu/containers.tf`, `tofu apply`
- Retire `ansible/files/stacks/` and the `ansible-stacks-deploy` playbook (no longer the source of truth)
