### PR TITLE
Migrate container backups to NixOS systemd timers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,8 @@
           "${nixpkgs}/nixos/modules/virtualisation/proxmox-image.nix"
           ./modules/base.nix
           ./modules/openbao-agent.nix
+          ./modules/ntfy-notify.nix
+          ./modules/backups.nix
           ./hosts/containers2/configuration.nix
         ];
       };

--- a/hosts/containers2/configuration.nix
+++ b/hosts/containers2/configuration.nix
@@ -12,10 +12,10 @@
   # Resolve via fw1 (Unbound recursive, which stubs LAN zone to dns1)
   networking.nameservers = [ "10.10.15.1" ];
 
-  # --- NFS mounts (mirror the Ansible-managed mounts on the live containers VM) ---
-  # Subset for now: just what's needed to consume the pre-migration snapshots
-  # and operate the existing services. Read-only shares (Books, Documents, etc.)
-  # follow once we're closer to cutover.
+  # --- NFS mounts ---
+  # RW shares are written by services on this host (paperless ingests, the
+  # arr stack writes to Media, config snapshots land in containers-configs).
+  # RO shares are read-only sources for the B2 + local backup sweeps.
   fileSystems."/mnt/nas/containers-configs" = {
     device = "10.10.15.4:/volume1/containers-configs";
     fsType = "nfs";
@@ -32,6 +32,73 @@
     device = "10.10.15.4:/volume1/paperless";
     fsType = "nfs";
     options = [ "rw" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  # Read-only NAS shares — backup sources only, never written from here.
+  fileSystems."/mnt/nas/Pictures" = {
+    device = "10.10.15.4:/volume1/Pictures";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/Documents" = {
+    device = "10.10.15.4:/volume1/Documents";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/Books" = {
+    device = "10.10.15.4:/volume1/Books";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/bp" = {
+    device = "10.10.15.4:/volume1/bp";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/caitstuff" = {
+    device = "10.10.15.4:/volume1/caitstuff";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/syncthing-data" = {
+    device = "10.10.15.4:/volume1/syncthing-data";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/backup" = {
+    device = "10.10.15.4:/volume1/backup";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/Misc" = {
+    device = "10.10.15.4:/volume1/Misc";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/tb" = {
+    device = "10.10.15.4:/volume1/tb";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/homelab-backups" = {
+    device = "10.10.15.4:/volume1/homelab-backups";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
+  };
+
+  fileSystems."/mnt/nas/tofu-state" = {
+    device = "10.10.15.4:/volume1/tofu-state";
+    fsType = "nfs";
+    options = [ "ro" "_netdev" "hard" "nofail" "vers=3" "noatime" ];
   };
 
   # Seagate 12TB USB backup drive (passed through from Proxmox).
@@ -105,10 +172,10 @@
   ];
 
   # --- OpenBao agent for secrets ---
-  # Currently delivers the cwage password hash. Stack secrets (.env,
-  # traefik basicauth, staticomment ssh deploy key) and lego-managed TLS
-  # certs are still mutable in /opt/stacks/ and are slated to move into
-  # the agent in a follow-up.
+  # Currently delivers the cwage password hash and the B2 backup credentials.
+  # Stack secrets (.env, traefik basicauth, staticomment ssh deploy key) and
+  # lego-managed TLS certs are still mutable in /opt/stacks/ and are slated
+  # to move into the agent in a follow-up.
   # roleId is per-host and CIDR-bound to 10.10.15.11.
   homelab.openbao-agent = {
     enable = true;
@@ -120,6 +187,94 @@
         field = "password_hash";
         destination = "/etc/secrets/cwage-password-hash";
       };
+
+      backup-b2-account = {
+        path = "kv/data/backup/backblaze";
+        field = "account_id";
+        destination = "/etc/secrets/backup/b2-account";
+      };
+      backup-b2-key = {
+        path = "kv/data/backup/backblaze";
+        field = "application_key";
+        destination = "/etc/secrets/backup/b2-key";
+      };
+      backup-b2crypt-pw = {
+        path = "kv/data/backup/rclone-crypt";
+        field = "password";
+        destination = "/etc/secrets/backup/b2crypt-pw";
+      };
+      # password2 (salt) intentionally omitted — this rclone crypt remote uses
+      # the default salt, not a custom one. Templating a non-existent field
+      # would write the literal string "<no value>" to disk and break rclone.
+    };
+  };
+
+  # --- ntfy.sh notifications ---
+  # OnFailure/OnSuccess hooks on the backup units pull last 20 journal lines
+  # and post them to this topic.
+  homelab.ntfy = {
+    enable = true;
+    topic = "https://ntfy.sh/cwage-homelab-backup";
+  };
+
+  # --- Backups ---
+  # Three jobs:
+  #   - configs (03:00): briefly stop/start each compose service while
+  #     rsyncing its named volume to /mnt/nas/containers-configs/
+  #   - b2 (03:40):       encrypted Backblaze sync (configs land here too,
+  #                       picked up via the containers-configs path)
+  #   - local (02:00):    full unencrypted copy to the USB drive at /mnt/nasbak
+  # Schedules are deliberately staggered: local first, then configs, then b2
+  # consumes the fresh containers-configs snapshot.
+  homelab.backups = {
+    local = {
+      enable = true;
+      paths = [
+        "Pictures"
+        "Documents"
+        "paperless"
+        "Books"
+        "bp"
+        "caitstuff"
+        "syncthing-data"
+        "backup"
+        "Misc"
+        "Media"
+        "tb"
+        "homelab-backups"
+        "containers-configs"
+        "tofu-state"
+      ];
+    };
+
+    configs = {
+      enable = true;
+      services = [
+        { name = "jellyfin";        mount = "/config"; }
+        { name = "sabnzbd";         mount = "/config"; }
+        { name = "radarr";          mount = "/config"; }
+        { name = "sonarr";          mount = "/config"; }
+        { name = "paperless-redis"; mount = "/data"; }
+      ];
+    };
+
+    b2 = {
+      enable = true;
+      paths = [
+        "Pictures"
+        "Documents"
+        "paperless"
+        "Books"
+        "bp"
+        "caitstuff"
+        "syncthing-data"
+        "backup"
+        "Misc"
+        "Media"
+        "homelab-backups"
+        "containers-configs"
+        "tofu-state"
+      ];
     };
   };
 }

--- a/modules/backups.nix
+++ b/modules/backups.nix
@@ -1,0 +1,386 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.homelab.backups;
+
+  # Shared rclone exclude patterns used by both b2 and local sweeps.
+  rcloneExcludes = [
+    "@eaDir/**"
+    "#recycle/**"
+    "*.db-wal"
+    "*.db-shm"
+    "**/logs/**"
+    "Downloads/incomplete/**"
+  ];
+
+  rcloneFlagsArray = ''
+    RCLONE_FLAGS=(
+      --log-level INFO
+      ${lib.concatMapStringsSep "\n      "
+        (e: "--exclude ${lib.escapeShellArg e}")
+        rcloneExcludes}
+    )
+  '';
+
+  shellPathArray = name: paths: ''
+    ${name}=(
+      ${lib.concatMapStringsSep "\n      " lib.escapeShellArg paths}
+    )
+  '';
+
+  # Common script preamble for the b2/local rclone sweeps.
+  rcloneSweepScript = { target, dest, paths, preflightExtra ? "", credsBlock ? "" }: ''
+    set -euo pipefail
+
+    START_TIME=$(date +%s)
+    NAS_ROOT=${lib.escapeShellArg cfg.nasRoot}
+    DEST=${lib.escapeShellArg dest}
+    ${shellPathArray "PATHS" paths}
+
+    ${preflightExtra}
+
+    ${credsBlock}
+
+    ${rcloneFlagsArray}
+
+    FAILED=()
+    SUCCEEDED=()
+
+    echo "Starting ${target} backup — ''${#PATHS[@]} path(s)"
+
+    for path in "''${PATHS[@]}"; do
+      src="$NAS_ROOT/$path"
+      ${if target == "B2"
+        then ''dest_path="b2crypt:$path"''
+        else ''dest_path="$DEST/$path"''}
+
+      if [[ ! -d "$src" ]]; then
+        echo "WARNING: missing source: $src"
+        FAILED+=("$path (not found)")
+        continue
+      fi
+
+      echo "Syncing: $src -> $dest_path"
+      if rclone sync "$src" "$dest_path" "''${RCLONE_FLAGS[@]}"; then
+        echo "OK: $path"
+        SUCCEEDED+=("$path")
+      else
+        echo "FAILED: $path"
+        FAILED+=("$path")
+      fi
+    done
+
+    DURATION=$(( $(date +%s) - START_TIME ))
+    echo "---"
+    echo "Backup complete (${target}): ''${#SUCCEEDED[@]} succeeded, ''${#FAILED[@]} failed (''${DURATION}s)"
+
+    if [[ ''${#FAILED[@]} -gt 0 ]]; then
+      echo "Failed paths:"
+      for p in "''${FAILED[@]}"; do echo "  - $p"; done
+      exit 1
+    fi
+  '';
+
+  notifyHooks = {
+    OnFailure = [ "notify-failure@%n.service" ];
+    OnSuccess = [ "notify-success@%n.service" ];
+  };
+in
+{
+  options.homelab.backups = {
+    nasRoot = lib.mkOption {
+      type = lib.types.str;
+      default = "/mnt/nas";
+      description = "Root path under which all NAS shares are mounted.";
+    };
+
+    b2 = {
+      enable = lib.mkEnableOption "Daily encrypted Backblaze B2 sync";
+
+      onCalendar = lib.mkOption {
+        type = lib.types.str;
+        default = "*-*-* 03:40:00";
+        description = "systemd OnCalendar expression for the B2 sync timer.";
+      };
+
+      paths = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+        example = [ "Pictures" "Documents" ];
+        description = "NAS share paths to sync, relative to nasRoot.";
+      };
+
+      cryptRemote = lib.mkOption {
+        type = lib.types.str;
+        default = "b2:cwagenas-backup";
+        description = "Underlying rclone remote that the b2crypt overlay wraps.";
+      };
+
+      secretsDir = lib.mkOption {
+        type = lib.types.str;
+        default = "/etc/secrets/backup";
+        description = ''
+          Directory holding openbao-agent-templated credential files.
+          Required: b2-account, b2-key, b2crypt-pw.
+          Optional: b2crypt-pw2 (only if rclone crypt was configured with a
+          custom salt — most setups don't use one).
+        '';
+      };
+    };
+
+    local = {
+      enable = lib.mkEnableOption "Daily local backup sync to USB drive";
+
+      onCalendar = lib.mkOption {
+        type = lib.types.str;
+        default = "*-*-* 02:00:00";
+        description = "systemd OnCalendar expression for the local sync timer.";
+      };
+
+      paths = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+        description = "NAS share paths to sync, relative to nasRoot.";
+      };
+
+      destination = lib.mkOption {
+        type = lib.types.str;
+        default = "/mnt/nasbak";
+        description = "Local mount point that receives the unencrypted copy.";
+      };
+    };
+
+    configs = {
+      enable = lib.mkEnableOption "Daily container volume snapshots";
+
+      onCalendar = lib.mkOption {
+        type = lib.types.str;
+        default = "*-*-* 03:00:00";
+        description = "systemd OnCalendar expression for the configs snapshot timer.";
+      };
+
+      composeFile = lib.mkOption {
+        type = lib.types.str;
+        default = "/opt/stacks/docker-compose.yml";
+        description = "Path to the docker compose file describing the stack.";
+      };
+
+      destination = lib.mkOption {
+        type = lib.types.str;
+        default = "/mnt/nas/containers-configs";
+        description = "Per-service volume snapshots are written under this directory.";
+      };
+
+      services = lib.mkOption {
+        type = lib.types.listOf (lib.types.submodule {
+          options = {
+            name = lib.mkOption {
+              type = lib.types.str;
+              description = "Compose service name.";
+            };
+            mount = lib.mkOption {
+              type = lib.types.str;
+              description = "In-container mount point of the named volume to snapshot.";
+            };
+          };
+        });
+        default = [];
+        example = [ { name = "jellyfin"; mount = "/config"; } ];
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.b2.enable {
+      systemd.services.backup-b2 = {
+        description = "Daily encrypted Backblaze B2 sync";
+        path = with pkgs; [ rclone coreutils ];
+        wants = [ "openbao-agent.service" ];
+        after = [ "openbao-agent.service" ];
+        unitConfig = notifyHooks // {
+          RequiresMountsFor = cfg.nasRoot;
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          User = "root";
+        };
+        script = rcloneSweepScript {
+          target = "B2";
+          dest = "b2crypt:";
+          paths = cfg.b2.paths;
+          credsBlock = ''
+            export RCLONE_CONFIG_B2_TYPE=b2
+            RCLONE_CONFIG_B2_ACCOUNT=$(cat ${lib.escapeShellArg "${cfg.b2.secretsDir}/b2-account"})
+            RCLONE_CONFIG_B2_KEY=$(cat ${lib.escapeShellArg "${cfg.b2.secretsDir}/b2-key"})
+            export RCLONE_CONFIG_B2_ACCOUNT RCLONE_CONFIG_B2_KEY
+
+            export RCLONE_CONFIG_B2CRYPT_TYPE=crypt
+            export RCLONE_CONFIG_B2CRYPT_REMOTE=${lib.escapeShellArg cfg.b2.cryptRemote}
+            RCLONE_CONFIG_B2CRYPT_PASSWORD=$(cat ${lib.escapeShellArg "${cfg.b2.secretsDir}/b2crypt-pw"})
+            export RCLONE_CONFIG_B2CRYPT_PASSWORD
+
+            # Salt (password2) is optional. Only export if openbao-agent has
+            # templated a real value — a stale file containing the literal
+            # "<no value>" sentinel (consul-template's output for a missing
+            # field) is rejected so rclone falls back to its default salt.
+            pw2=$(cat ${lib.escapeShellArg "${cfg.b2.secretsDir}/b2crypt-pw2"} 2>/dev/null) || pw2=""
+            if [[ -n "$pw2" && "$pw2" != "<no value>" ]]; then
+              export RCLONE_CONFIG_B2CRYPT_PASSWORD2="$pw2"
+            fi
+          '';
+        };
+      };
+
+      systemd.timers.backup-b2 = {
+        description = "Daily encrypted Backblaze B2 sync timer";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnCalendar = cfg.b2.onCalendar;
+          Persistent = true;
+        };
+      };
+    })
+
+    (lib.mkIf cfg.local.enable {
+      systemd.services.backup-local = {
+        description = "Daily local backup sync to USB drive";
+        path = with pkgs; [ rclone coreutils util-linux ];
+        unitConfig = notifyHooks // {
+          RequiresMountsFor = "${cfg.nasRoot} ${cfg.local.destination}";
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          User = "root";
+        };
+        script = rcloneSweepScript {
+          target = "LOCAL";
+          dest = cfg.local.destination;
+          paths = cfg.local.paths;
+          preflightExtra = ''
+            if ! mountpoint -q "$DEST"; then
+              echo "ERROR: $DEST is not mounted — refusing to write to root fs"
+              exit 1
+            fi
+          '';
+        };
+      };
+
+      systemd.timers.backup-local = {
+        description = "Daily local backup sync timer";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnCalendar = cfg.local.onCalendar;
+          Persistent = true;
+        };
+      };
+    })
+
+    (lib.mkIf cfg.configs.enable {
+      systemd.services.backup-configs = {
+        description = "Daily snapshot of container named volumes to NAS";
+        path = with pkgs; [ docker rsync coreutils util-linux gnused ];
+        wants = [ "docker.service" ];
+        after = [ "docker.service" ];
+        unitConfig = notifyHooks // {
+          RequiresMountsFor = cfg.configs.destination;
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          User = "root";
+        };
+        script = ''
+          set -euo pipefail
+
+          START_TIME=$(date +%s)
+          COMPOSE_FILE=${lib.escapeShellArg cfg.configs.composeFile}
+          DEST_ROOT=${lib.escapeShellArg cfg.configs.destination}
+
+          ${shellPathArray "SERVICES"
+              (map (s: "${s.name}:${s.mount}") cfg.configs.services)}
+
+          # Pre-flight
+          [[ -f "$COMPOSE_FILE" ]] || { echo "ERROR: compose file missing: $COMPOSE_FILE"; exit 1; }
+          mountpoint -q "$DEST_ROOT" || { echo "ERROR: $DEST_ROOT not a mountpoint"; exit 1; }
+          touch "$DEST_ROOT/.backup-configs-write-test" 2>/dev/null \
+            || { echo "ERROR: $DEST_ROOT not writable"; exit 1; }
+          rm -f "$DEST_ROOT/.backup-configs-write-test"
+
+          SUCCEEDED=()
+          FAILED=()
+
+          echo "Starting config backup — ''${#SERVICES[@]} service(s)"
+
+          for entry in "''${SERVICES[@]}"; do
+            svc="''${entry%%:*}"
+            mount_dest="''${entry##*:}"
+            dest="$DEST_ROOT/$svc"
+
+            echo "---"
+            echo "Service: $svc (mount: $mount_dest)"
+
+            cid=$(docker compose -f "$COMPOSE_FILE" ps -q "$svc" 2>/dev/null || true)
+            if [[ -z "$cid" ]]; then
+              echo "  ERROR: no running container for service $svc"
+              FAILED+=("$svc (not running)")
+              continue
+            fi
+
+            vol=$(docker inspect "$cid" --format \
+              "{{range .Mounts}}{{if and (eq .Type \"volume\") (eq .Destination \"$mount_dest\")}}{{.Name}}{{end}}{{end}}")
+            if [[ -z "$vol" ]]; then
+              echo "  ERROR: no named volume mounted at $mount_dest in $svc"
+              FAILED+=("$svc (volume lookup failed)")
+              continue
+            fi
+
+            voldir=$(docker volume inspect "$vol" --format '{{.Mountpoint}}')
+            echo "  Resolved volume: $vol at $voldir"
+
+            mkdir -p "$dest"
+
+            echo "  Stopping $svc..."
+            if ! docker compose -f "$COMPOSE_FILE" stop "$svc"; then
+              echo "  ERROR: failed to stop $svc"
+              FAILED+=("$svc (stop failed)")
+              continue
+            fi
+
+            echo "  Syncing $voldir/ -> $dest/"
+            if rsync -aHAX --delete "$voldir/" "$dest/"; then
+              echo "  OK: $svc"
+              SUCCEEDED+=("$svc")
+            else
+              echo "  ERROR: rsync failed"
+              FAILED+=("$svc (rsync failed)")
+            fi
+
+            echo "  Starting $svc..."
+            if ! docker compose -f "$COMPOSE_FILE" start "$svc"; then
+              echo "  ERROR: failed to start $svc — manual intervention may be required"
+              FAILED+=("$svc (restart failed)")
+            fi
+          done
+
+          DURATION=$(( $(date +%s) - START_TIME ))
+          echo "---"
+          echo "Config backup complete: ''${#SUCCEEDED[@]}/''${#SERVICES[@]} succeeded (''${DURATION}s)"
+
+          if [[ ''${#FAILED[@]} -gt 0 ]]; then
+            echo "Failed:"
+            for f in "''${FAILED[@]}"; do echo "  - $f"; done
+            exit 1
+          fi
+        '';
+      };
+
+      systemd.timers.backup-configs = {
+        description = "Daily container volume snapshot timer";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnCalendar = cfg.configs.onCalendar;
+          Persistent = true;
+        };
+      };
+    })
+  ];
+}

--- a/modules/backups.nix
+++ b/modules/backups.nix
@@ -54,9 +54,12 @@ let
         then ''dest_path="b2crypt:$path"''
         else ''dest_path="$DEST/$path"''}
 
-      if [[ ! -d "$src" ]]; then
-        echo "WARNING: missing source: $src"
-        FAILED+=("$path (not found)")
+      # Source MUST be an active mountpoint, not just an extant directory.
+      # rclone sync --delete against an empty stale mountpoint dir would
+      # wipe the destination — fail this path closed instead.
+      if ! mountpoint -q "$src"; then
+        echo "ERROR: $src is not a mountpoint — refusing to sync (would delete destination)"
+        FAILED+=("$path (source not mounted)")
         continue
       fi
 
@@ -85,6 +88,14 @@ let
     OnFailure = [ "notify-failure@%n.service" ];
     OnSuccess = [ "notify-success@%n.service" ];
   };
+
+  # Build a space-separated RequiresMountsFor= value: each entry is resolved
+  # by systemd to its containing mount unit, so the service won't start until
+  # those NFS shares are actually mounted (not just their parent directory
+  # existing). Pairs with the in-script `mountpoint -q` check for cases where
+  # systemd thinks a mount is up but it has gone stale mid-run.
+  mkMountReqs = paths: lib.concatStringsSep " "
+    (map (p: "${cfg.nasRoot}/${p}") paths);
 in
 {
   options.homelab.backups = {
@@ -194,11 +205,11 @@ in
     (lib.mkIf cfg.b2.enable {
       systemd.services.backup-b2 = {
         description = "Daily encrypted Backblaze B2 sync";
-        path = with pkgs; [ rclone coreutils ];
+        path = with pkgs; [ rclone coreutils util-linux ];
         wants = [ "openbao-agent.service" ];
         after = [ "openbao-agent.service" ];
         unitConfig = notifyHooks // {
-          RequiresMountsFor = cfg.nasRoot;
+          RequiresMountsFor = mkMountReqs cfg.b2.paths;
         };
         serviceConfig = {
           Type = "oneshot";
@@ -246,7 +257,7 @@ in
         description = "Daily local backup sync to USB drive";
         path = with pkgs; [ rclone coreutils util-linux ];
         unitConfig = notifyHooks // {
-          RequiresMountsFor = "${cfg.nasRoot} ${cfg.local.destination}";
+          RequiresMountsFor = "${cfg.local.destination} ${mkMountReqs cfg.local.paths}";
         };
         serviceConfig = {
           Type = "oneshot";

--- a/modules/openbao-agent.nix
+++ b/modules/openbao-agent.nix
@@ -128,6 +128,12 @@ in
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
 
+      # Restart the daemon when its config or bound role_id changes — without
+      # this, edits to the secrets list update /etc/openbao/agent.hcl on disk
+      # but the running process keeps using its in-memory template list.
+      restartTriggers = [ agentConfig ]
+        ++ lib.optional (cfg.roleId != null) cfg.roleId;
+
       # Don't start until role_id exists (written by NixOS activation if
       # roleId is set, or delivered out-of-band by Tofu/cloud-init)
       unitConfig.ConditionPathExists = "/etc/openbao/role_id";


### PR DESCRIPTION
Migrates the daily backup jobs that were running on the (now powered-off) containers VM into NixOS systemd timers on containers2. Backups have been silently broken since the cutover — `playbooks/backup-{deploy,configs}.yml` still target `container_hosts`, which now resolves to a powered-off VM.

## What's new

Three timer-driven units in a new `modules/backups.nix`:

| Unit | Schedule | Purpose |
|---|---|---|
| `backup-local.timer` | 02:00 daily | rclone sync NAS shares → USB drive at `/mnt/nasbak` |
| `backup-configs.timer` | 03:00 daily | stop/rsync/start each named compose volume → `/mnt/nas/containers-configs/` |
| `backup-b2.timer` | 03:40 daily | encrypted Backblaze B2 sync (creds via openbao-agent) |

`backup-local` and `backup-b2` keep their pre-cutover schedules. `backup-configs` was previously manual via `make ansible-backup-configs`; it's now on a daily timer so the fresh snapshot lands in `containers-configs` before b2 picks it up. ntfy `OnFailure`/`OnSuccess` notifications reuse the existing `homelab.ntfy` module (topic `cwage-homelab-backup`).

## Supporting changes

- **`hosts/containers2/configuration.nix`**: adds 11 read-only NFS mounts (Books, Documents, Pictures, Misc, bp, caitstuff, syncthing-data, backup, tb, homelab-backups, tofu-state) that the sweeps read from. Previously deferred post-cutover. Adds B2 + rclone-crypt credentials to `homelab.openbao-agent.secrets` (account_id, application_key, password). `password2` is intentionally omitted — this remote uses rclone's default salt.

- **`modules/openbao-agent.nix`** (drive-by fix): adds `restartTriggers` on the agent's HCL content. Without this, edits to the secrets list updated `/etc/openbao/agent.hcl` on disk but the running daemon held its old in-memory template list, silently re-rendering removed secrets. Caught during testing.

- **`flake.nix`**: containers2 imports `ntfy-notify.nix` (now wired to the backup units) and the new `backups.nix`.

The old Ansible playbooks (`backup-deploy.yml`, `backup-configs.yml`) and `backup/` Docker tooling stay in place — follow-up PR removes them once this has run a few cycles in production.

## OpenBao policy

Run before merging — extends the existing `nixos-host` policy with `backup-remote`:

```
bao read auth/approle/role/containers2  # confirm current values match defaults
bao write auth/approle/role/containers2 \
  bind_secret_id=false \
  secret_id_bound_cidrs="" \
  token_bound_cidrs="10.10.15.11/32" \
  token_policies="nixos-host,backup-remote" \
  token_ttl=1h \
  token_max_ttl=4h \
  token_period=1h
```

## Test Plan

All three jobs tested live on containers2 prior to PR:

- [x] `backup-local` → `Backup complete (LOCAL): 14 succeeded, 0 failed (317s)`
- [x] `backup-configs` → `Config backup complete: 5/5 succeeded (31s)`
- [x] `backup-b2` → `Backup complete (B2): 13 succeeded, 0 failed`
- [x] OnSuccess ntfy notifications received for each
- [x] `systemctl list-timers` confirms all three queued at expected times
- [x] Audited codebase + powered-off VM for other scheduled jobs needing migration — none found
