### PR TITLE
Stop leaking secrets from openbao-test playbook

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -71,7 +71,7 @@ containers-check: ## Dry-run container hosts configuration with --check/--diff
 	$(DC) run --rm ansible ansible-playbook playbooks/containers.yml -vv --check --diff $(OPTS)
 
 openbao-test: ## Test OpenBao connectivity and secret retrieval (requires BAO_TOKEN)
-	$(DC) run --rm ansible ansible-playbook playbooks/openbao-test.yml -vv $(OPTS)
+	$(DC) run --rm ansible ansible-playbook playbooks/openbao-test.yml $(OPTS)
 
 gaming: ## Full gaming server provisioning (all active profiles) [PROFILE=name]
 	$(DC) run --rm ansible ansible-playbook playbooks/gaming.yml -vv $(if $(PROFILE),-e 'gaming_profile_filter=$(PROFILE)',) $(OPTS)

--- a/ansible/playbooks/openbao-test.yml
+++ b/ansible/playbooks/openbao-test.yml
@@ -51,6 +51,7 @@
                                 url=openbao_addr,
                                 token=openbao_token,
                                 validate_certs=openbao_validate_certs) }}"
+      no_log: true
 
     - name: Display retrieved backup token (masked)
       ansible.builtin.debug:


### PR DESCRIPTION
Stop leaking the backup token from `make ansible-openbao-test`. Closes part of #220.

## Changes

- **`ansible/Makefile`**: drop `-vv` from the `openbao-test` target. Verbose output remains opt-in via `OPTS='-vv'`.
- **`ansible/playbooks/openbao-test.yml`**: add `no_log: true` to the `set_fact` task that runs the `vault_kv2_get` lookup, so the unredacted value never hits stdout even if someone re-enables verbose output.

## Why

Under `-vv`, the lookup task prints the full `ansible_facts` it just set, including the raw secret value. The subsequent debug task masks the token to 8 chars, but the unmasked value already landed in stdout (and conversation logs / scrollback / CI output, depending on where the playbook ran). Either fix alone closes the leak — doing both for defense in depth.

## Follow-up

The backup token that leaked during the bao2 migration session still needs to be rotated. Tracked separately, not part of this PR.

## Test Plan

- [ ] `make ansible-openbao-test` succeeds and the only token-shaped output is the truncated `Retrieved backup token: xxxxxxxx...` from the masking debug task.
- [ ] `make ansible-openbao-test OPTS='-vv'` confirms that even with verbose mode forced on, the `set_fact` task is suppressed (Ansible should print `censored: 'the output has been hidden due to the fact that 'no_log: true' was specified for this result'`).
