### PR TITLE
Auto-deliver wildcard cert via openbao-agent on bao2 + containers2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TOFU_TARGETS := help build shell init plan apply destroy fmt validate trufflehog
 LEGO_TARGETS := help run renew renew-staging renew-force list show fetch-creds store retrieve
 BACKUP_TARGETS := help build shell clean local local-dry b2 b2-dry
 NIX_TARGETS := help build shell template deploy deploy-host clean clean-all
-OPENBAO_TARGETS := help approle-enable approle-create-role approle-show-role approle-list shell
+OPENBAO_TARGETS := help build approle-enable approle-create-role approle-show-role approle-list shell
 TRUFFLEHOG_ARGS ?= filesystem /repo --fail --no-update --exclude-paths /repo/.trufflehog-exclude.txt
 
 .DEFAULT_GOAL := help

--- a/docs/tls-certificates.md
+++ b/docs/tls-certificates.md
@@ -7,15 +7,20 @@ Wildcard TLS certificate management for `*.lan.quietlife.net` using Let's Encryp
 ```
 lego/ (ACME client)        OpenBao                  Deploy
 ───────────────────        ───────                  ──────
-Let's Encrypt cert    →  Stored at            →  Traefik (containers2):
-via DNS-01 challenge     kv/infra/certs/          manual scp → /opt/stacks/certs/
-(Cloudflare API)         lan.quietlife.net         + docker restart traefik
-                                                   (TODO: NixOS-driven delivery — #220)
+Let's Encrypt cert    →  Stored at            →  bao2 (own listener):
+via DNS-01 challenge     kv/infra/certs/          openbao-agent → /var/lib/openbao/tls/
+(Cloudflare API)         lan.quietlife.net         + systemctl reload openbao (SIGHUP)
+
+                                                  Traefik (containers2):
+                                                   openbao-agent → /opt/stacks/certs/
+                                                   + docker restart traefik
 
                                                   Proxmox web UI (pve1):
                                                    make ansible-proxmox
                                                    (proxmox_certs role)
 ```
+
+bao2 and containers2 both run `homelab.openbao-agent` (see `modules/openbao-agent.nix`) with templates that deliver the cert/key from KV to disk and fire a post-rotation hook. Agent polls KV roughly every 1-2 minutes, so a `make lego-store` is automatically picked up without manual deploy. bao2 talks to its own openbao via loopback with TLS verification disabled — that breaks the chicken-and-egg where bao2's listener TLS depends on the very cert the agent is responsible for refreshing.
 
 ## Certificate lifecycle
 
@@ -37,40 +42,32 @@ Cloudflare API credentials (API token, zone ID) are fetched from OpenBao at depl
 
 ### Deployment
 
-The cert is retrieved from OpenBao and deployed to services:
+After `make lego-store` writes the new cert to `kv/infra/certs/lan.quietlife.net`, deployment to consumers happens automatically except for Proxmox:
 
-- **Traefik** (containers2): the cert and key currently live as mutable files in `/opt/stacks/certs/` (placed imperatively after the NixOS migration; slated to move to a NixOS-driven lego workflow). Traefik picks them up via the `traefik-tls.yml` file provider.
-- **Proxmox** (pve1): `make ansible-proxmox` deploys cert via the `proxmox_certs` role for the Proxmox web UI
-
-**Note:** Traefik does not automatically reload bind-mounted cert files. After replacing them, restart the container: `ssh containers2 'docker restart traefik'`.
+- **bao2** (its own TCP listener): `homelab.openbao-agent` template renders the cert/key from KV to `/var/lib/openbao/tls/{tls.crt,tls.key}` (owned `openbao:openbao`) and fires `systemctl reload openbao` — SIGHUP makes openbao re-read TLS in place without re-sealing. Picked up within ~2 minutes of `lego-store`.
+- **Traefik** (containers2): same agent pattern, renders to `/opt/stacks/certs/lan.quietlife.net.{crt,key}` (owned `deploy:users`) and fires `docker restart traefik` (~1-2s blip on rotation).
+- **Proxmox** (pve1): `make ansible-proxmox` — still Ansible-driven for the Proxmox web UI cert via the `proxmox_certs` role.
 
 ### Renewal when the cert is already expired
 
-If the cert has already expired, OpenBao (which serves its own TLS on port 8200) will also have the expired cert. Both `make lego-store` (curl to OpenBao) and Ansible's OpenBao lookups will fail with `SSL: CERTIFICATE_VERIFY_FAILED`. To break the chicken-and-egg cycle:
+If the cert has already expired, OpenBao (which serves its own TLS on port 8200) will also have the expired cert and the workstation can't trust it for `make lego-store`. The recovery is short:
 
 ```bash
-# 1. Renew cert from Let's Encrypt (this doesn't talk to OpenBao)
+# 1. Renew cert from Let's Encrypt (doesn't talk to OpenBao).
 make lego-renew
 
-# 2. Store in OpenBao with TLS verification disabled
+# 2. Push the new cert to OpenBao with TLS verification disabled. The
+#    workstation can't validate bao2's expired cert, so verify-skip is
+#    needed for this one push.
 BAO_SKIP_VERIFY=true make lego-store
 
-# 3. Copy the renewed cert/key onto containers2 and restart Traefik. The
-#    target dir is 0700 deploy:users, so we stage in /tmp and sudo install.
-#    (containers2 will pick this up automatically once cert delivery is
-#    moved into openbao-agent / a NixOS lego module — until then it's manual)
-scp lego/certs/certificates/_.lan.quietlife.net.crt containers2:/tmp/lan.quietlife.net.crt
-scp lego/certs/certificates/_.lan.quietlife.net.key containers2:/tmp/lan.quietlife.net.key
-ssh containers2 'sudo install -o deploy -g users -m 0644 /tmp/lan.quietlife.net.crt /opt/stacks/certs/lan.quietlife.net.crt && sudo install -o deploy -g users -m 0600 /tmp/lan.quietlife.net.key /opt/stacks/certs/lan.quietlife.net.key && rm -f /tmp/lan.quietlife.net.crt /tmp/lan.quietlife.net.key && docker restart traefik'
+# 3. bao2 and containers2 auto-rotate within ~2 minutes — no further
+#    action needed. bao2's openbao-agent connects via loopback with TLS
+#    verification disabled (intentional, see modules/openbao-agent.nix
+#    and hosts/openbao/configuration.nix), so an expired listener cert
+#    doesn't block the agent from refreshing it.
 
-# 4. Update OpenBao's own TLS cert on bao2 and restart the service. The
-#    target dir is 0750 openbao:openbao, so the same /tmp staging trick.
-#    (Manual until the cert auto-renewal module lands — issue #220.)
-scp lego/certs/certificates/_.lan.quietlife.net.crt bao2:/tmp/tls.crt
-scp lego/certs/certificates/_.lan.quietlife.net.key bao2:/tmp/tls.key
-ssh bao2 'sudo install -o openbao -g openbao -m 0644 /tmp/tls.crt /var/lib/openbao/tls/tls.crt && sudo install -o openbao -g openbao -m 0600 /tmp/tls.key /var/lib/openbao/tls/tls.key && rm -f /tmp/tls.crt /tmp/tls.key && sudo systemctl restart openbao'
-
-# 5. Subsequent runs (proxmox, etc.) should work normally now
+# 4. Push the new cert to the Proxmox web UI (still Ansible-managed).
 make ansible-proxmox
 ```
 

--- a/hosts/containers2/configuration.nix
+++ b/hosts/containers2/configuration.nix
@@ -224,7 +224,9 @@
         group = "users";
         permissions = "0600";
         manageDestinationDir = false;
-        # Command on the key only (see openbao-agent module's race note).
+        # Command on the key, which sorts after traefik-tls-cert and is
+        # therefore rendered second (see modules/openbao-agent.nix). The
+        # command fires only after both files are on disk.
         # Traefik doesn't watch bind-mounted cert files, so a restart is
         # required — `docker restart` is idempotent and ~2s, fine for a
         # quarterly rotation.

--- a/hosts/containers2/configuration.nix
+++ b/hosts/containers2/configuration.nix
@@ -203,6 +203,33 @@
       # password2 (salt) intentionally omitted — this rclone crypt remote uses
       # the default salt, not a custom one. Templating a non-existent field
       # would write the literal string "<no value>" to disk and break rclone.
+
+      # LE wildcard cert delivery for Traefik. The dir at /opt/stacks/certs
+      # is 0700 deploy:users (declared above), so we set owner/group on the
+      # rendered files explicitly and tell the agent not to redeclare the dir.
+      traefik-tls-cert = {
+        path = "kv/data/infra/certs/lan.quietlife.net";
+        field = "certificate";
+        destination = "/opt/stacks/certs/lan.quietlife.net.crt";
+        owner = "deploy";
+        group = "users";
+        permissions = "0644";
+        manageDestinationDir = false;
+      };
+      traefik-tls-key = {
+        path = "kv/data/infra/certs/lan.quietlife.net";
+        field = "private_key";
+        destination = "/opt/stacks/certs/lan.quietlife.net.key";
+        owner = "deploy";
+        group = "users";
+        permissions = "0600";
+        manageDestinationDir = false;
+        # Command on the key only (see openbao-agent module's race note).
+        # Traefik doesn't watch bind-mounted cert files, so a restart is
+        # required — `docker restart` is idempotent and ~2s, fine for a
+        # quarterly rotation.
+        command = "${pkgs.docker}/bin/docker restart traefik";
+      };
     };
   };
 

--- a/hosts/openbao/configuration.nix
+++ b/hosts/openbao/configuration.nix
@@ -89,8 +89,10 @@
         group = "openbao";
         permissions = "0600";
         manageDestinationDir = false;
-        # Command set on the key (rendered second alphabetically, but order
-        # isn't guaranteed — see the openbao-agent module for the race note).
+        # Command on the key, which sorts after tls-cert and is therefore
+        # rendered second by openbao-agent (templates are emitted in
+        # alphabetical order of the secret name and consul-template
+        # processes them sequentially — see modules/openbao-agent.nix).
         # `reload` (NOT reload-or-restart) — SIGHUP re-reads TLS in place
         # without re-sealing. A restart would leave openbao sealed and
         # require manual unseal, so we accept that a hard reload failure

--- a/hosts/openbao/configuration.nix
+++ b/hosts/openbao/configuration.nix
@@ -51,18 +51,51 @@
     cluster_addr = "https://bao.lan.quietlife.net:8201"
   '';
 
-  # --- OpenBao agent for secrets (cwage password hash) ---
-  # Fetches from bao.lan.quietlife.net which resolves to this host. The agent
-  # waits and retries if the local server is sealed.
+  # --- OpenBao agent for secrets ---
+  # Connects via loopback with TLS verification disabled to break the
+  # chicken-and-egg: bao2's TCP listener uses the very TLS cert this agent is
+  # responsible for refreshing. Loopback-only means there's no MITM concern,
+  # and skipping verification means an expired cert can still be replaced.
+  # The agent waits and retries if the local server is sealed.
   homelab.openbao-agent = {
     enable = true;
-    tlsSkipVerify = false;
+    address = "https://localhost:8200";
+    tlsSkipVerify = true;
     roleId = "9f69c83d-c515-58d5-20aa-260e2f63a507";
     secrets = {
       cwage-password-hash = {
         path = "kv/data/infra/users/cwage";
         field = "password_hash";
         destination = "/etc/secrets/cwage-password-hash";
+      };
+
+      # LE wildcard cert delivery for bao2's own TCP listener. The cert dir
+      # is created and owned by the openbao server module above, so we tell
+      # the agent module not to redeclare it.
+      tls-cert = {
+        path = "kv/data/infra/certs/lan.quietlife.net";
+        field = "certificate";
+        destination = "/var/lib/openbao/tls/tls.crt";
+        owner = "openbao";
+        group = "openbao";
+        permissions = "0644";
+        manageDestinationDir = false;
+      };
+      tls-key = {
+        path = "kv/data/infra/certs/lan.quietlife.net";
+        field = "private_key";
+        destination = "/var/lib/openbao/tls/tls.key";
+        owner = "openbao";
+        group = "openbao";
+        permissions = "0600";
+        manageDestinationDir = false;
+        # Command set on the key (rendered second alphabetically, but order
+        # isn't guaranteed — see the openbao-agent module for the race note).
+        # `reload` (NOT reload-or-restart) — SIGHUP re-reads TLS in place
+        # without re-sealing. A restart would leave openbao sealed and
+        # require manual unseal, so we accept that a hard reload failure
+        # silently leaves the old cert active until the next render cycle.
+        command = "systemctl reload openbao";
       };
     };
   };
@@ -72,6 +105,14 @@
     wantedBy = [ "multi-user.target" ];
     after = [ "network-online.target" ];
     wants = [ "network-online.target" ];
+
+    # Reload (SIGHUP) on unit changes instead of NixOS's default restart.
+    # A restart leaves openbao sealed and requires manual unseal — too high
+    # a cost for routine config tweaks. SIGHUP re-reads listener TLS in
+    # place; binary upgrades that genuinely need a restart are rare and can
+    # be handled manually with `systemctl restart openbao && bao operator
+    # unseal …`.
+    reloadIfChanged = true;
 
     # Don't start until TLS materials are staged out-of-band on first boot.
     # Both files required: missing key would crash-loop the server.
@@ -84,6 +125,10 @@
       User = "openbao";
       Group = "openbao";
       ExecStart = "${pkgs.openbao}/bin/bao server -config=/etc/openbao-server/openbao.hcl";
+      # SIGHUP makes openbao re-read TLS files on disk WITHOUT re-sealing —
+      # what we want when openbao-agent rotates the cert under us. A restart
+      # would leave openbao sealed and require manual unseal.
+      ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       Restart = "on-failure";
       RestartSec = "5s";
       ProtectSystem = "strict";

--- a/lego/README.md
+++ b/lego/README.md
@@ -29,9 +29,8 @@ make fetch-creds      # test OpenBao credential retrieval (masked output)
 make renew            # get new cert from Let's Encrypt
 make store            # push to OpenBao
 # Then deploy:
-#   Traefik (containers2): the cert/key live at /opt/stacks/certs/ but the
-#     dir is 0700 deploy:users — see docs/tls-certificates.md for the
-#     stage-in-/tmp + sudo install procedure, plus `docker restart traefik`.
+#   Traefik (containers2) and bao2: auto-deployed via openbao-agent within
+#     ~2 minutes of `make store`. No further action needed.
 #   Proxmox web UI:        make ansible-proxmox
 ```
 

--- a/modules/openbao-agent.nix
+++ b/modules/openbao-agent.nix
@@ -123,18 +123,20 @@ in
             type = lib.types.nullOr lib.types.str;
             default = null;
             description = ''
-              Command to run after the file is rendered (i.e. on rotation).
-              Typical use: 'systemctl reload-or-restart <svc>' or
-              'docker restart <container>'. The agent runs as root so this
-              command runs as root.
+              Command to run after the destination file is rendered (i.e.
+              on rotation). The agent runs as root, so this command runs
+              as root. Typical: 'systemctl reload <svc>' or
+              'docker restart <container>'.
 
-              Caveat: when a single KV secret is fanned out to multiple
-              destinations (e.g. cert + key), the agent renders templates
-              concurrently and the command fires per-template. Set the
-              command on only ONE of the destinations (typically the last one
-              written) and accept the rare race where the post-rotation
-              service restarts mid-fanout — Restart=on-failure picks up the
-              consistent state on the next attempt.
+              Multi-file fanout (e.g. cert + key from the same KV path):
+              set the command on only ONE secret, the one rendered LAST.
+              openbao-agent (consul-template under the hood) renders
+              templates sequentially in their HCL declaration order, which
+              this module emits in alphabetical order of the cfg.secrets
+              attribute name. Naming pair members so that the one carrying
+              the command sorts last (e.g. `tls-key` after `tls-cert`)
+              guarantees the command fires only after both files are on
+              disk, so the consumer never reloads mid-fanout.
             '';
           };
           manageDestinationDir = lib.mkOption {

--- a/modules/openbao-agent.nix
+++ b/modules/openbao-agent.nix
@@ -4,10 +4,17 @@ let
   cfg = config.homelab.openbao-agent;
 
   # Generate agent config HCL from module options
-  # Collect unique parent directories of all secret destinations
-  secretDirs = lib.unique (lib.mapAttrsToList
+  # All unique parent directories of secret destinations (used for the agent
+  # service's ReadWritePaths, regardless of who creates the dir).
+  allSecretDirs = lib.unique (lib.mapAttrsToList
     (_: secret: builtins.dirOf secret.destination)
     cfg.secrets);
+
+  # Subset whose parent dir we should auto-create via tmpfiles. Excludes any
+  # dir that's already declared in a host config (manageDestinationDir = false).
+  managedSecretDirs = lib.unique (lib.mapAttrsToList
+    (_: secret: builtins.dirOf secret.destination)
+    (lib.filterAttrs (_: secret: secret.manageDestinationDir) cfg.secrets));
 
   agentConfig = ''
     vault {
@@ -36,6 +43,9 @@ let
       contents = "{{ with secret \"${secret.path}\" }}{{ index .Data.data \"${secret.field}\" }}{{ end }}"
       destination = "${secret.destination}"
       perms = "${secret.permissions}"
+      ${lib.optionalString (secret.owner != null) ''user = "${secret.owner}"''}
+      ${lib.optionalString (secret.group != null) ''group = "${secret.group}"''}
+      ${lib.optionalString (secret.command != null) ''command = "${secret.command}"''}
     }
     '') cfg.secrets)}
   '';
@@ -92,6 +102,54 @@ in
             default = "0400";
             description = "File permissions for the rendered secret.";
           };
+          owner = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = ''
+              Owning user for the rendered file. Null leaves it as the agent
+              process user (root). Required when the consuming service runs as
+              a non-root user that cannot otherwise read the file.
+            '';
+          };
+          group = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = ''
+              Owning group for the rendered file. Null leaves it as the agent
+              process group (root).
+            '';
+          };
+          command = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = ''
+              Command to run after the file is rendered (i.e. on rotation).
+              Typical use: 'systemctl reload-or-restart <svc>' or
+              'docker restart <container>'. The agent runs as root so this
+              command runs as root.
+
+              Caveat: when a single KV secret is fanned out to multiple
+              destinations (e.g. cert + key), the agent renders templates
+              concurrently and the command fires per-template. Set the
+              command on only ONE of the destinations (typically the last one
+              written) and accept the rare race where the post-rotation
+              service restarts mid-fanout — Restart=on-failure picks up the
+              consistent state on the next attempt.
+            '';
+          };
+          manageDestinationDir = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Whether the module should auto-create the destination's parent
+              directory (0750 root:root) via systemd.tmpfiles. Set to false
+              when the directory is already declared elsewhere in the host
+              config with the ownership/perms the consumer needs (e.g.
+              /var/lib/openbao/tls owned by openbao:openbao on bao2). The
+              agent's ReadWritePaths still includes the parent dir either
+              way, so the agent can write into it.
+            '';
+          };
         };
       });
       default = {};
@@ -107,7 +165,7 @@ in
     systemd.tmpfiles.rules = [
       "d /etc/openbao 0750 root root -"
       "d /run/openbao-agent 0750 root root -"
-    ] ++ map (dir: "d ${dir} 0750 root root -") secretDirs;
+    ] ++ map (dir: "d ${dir} 0750 root root -") managedSecretDirs;
 
     # Write role_id if provided in config (not secret with CIDR binding)
     environment.etc."openbao/role_id" = lib.mkIf (cfg.roleId != null) {
@@ -146,7 +204,7 @@ in
         RestartSec = "5s";
         # Hardening
         ProtectSystem = "strict";
-        ReadWritePaths = [ "/run/openbao-agent" ] ++ secretDirs;
+        ReadWritePaths = [ "/run/openbao-agent" ] ++ allSecretDirs;
         ProtectHome = true;
         NoNewPrivileges = true;
       };

--- a/modules/openbao-agent.nix
+++ b/modules/openbao-agent.nix
@@ -43,9 +43,9 @@ let
       contents = "{{ with secret \"${secret.path}\" }}{{ index .Data.data \"${secret.field}\" }}{{ end }}"
       destination = "${secret.destination}"
       perms = "${secret.permissions}"
-      ${lib.optionalString (secret.owner != null) ''user = "${secret.owner}"''}
-      ${lib.optionalString (secret.group != null) ''group = "${secret.group}"''}
-      ${lib.optionalString (secret.command != null) ''command = "${secret.command}"''}
+      ${lib.optionalString (secret.owner != null) ''user = ${builtins.toJSON secret.owner}''}
+      ${lib.optionalString (secret.group != null) ''group = ${builtins.toJSON secret.group}''}
+      ${lib.optionalString (secret.command != null) ''command = ${builtins.toJSON secret.command}''}
     }
     '') cfg.secrets)}
   '';

--- a/openbao/Dockerfile
+++ b/openbao/Dockerfile
@@ -1,0 +1,7 @@
+FROM openbao/openbao:2.4.4
+
+# Add commonly-needed CLI tools for ad-hoc secret/cert work. The upstream
+# openbao image is alpine + bao only — no jq for JSON output, no openssl
+# for cert inspection, no curl for raw API pokes — so the basics live here.
+# Image's default USER is root, so no user switch needed.
+RUN apk add --no-cache jq openssl curl

--- a/openbao/Makefile
+++ b/openbao/Makefile
@@ -7,12 +7,15 @@ DC := docker compose --env-file ../.env
 
 # Admin targets fetch the approle-admin token from KV (using the deploy
 # token in .env), then run the privileged command with it. The admin token
-# never touches .env or disk. EXTRA_CIDRS is passed through for create-role
-# (used when an agent needs to connect from an additional CIDR like 127.0.0.1).
+# never touches .env or disk. EXTRA_CIDRS / EXTRA_POLICIES are passed through
+# for create-role to support hosts that need extra source IPs (e.g. bao2's
+# 127.0.0.1/32) or extra policies on top of nixos-host (e.g. containers2's
+# backup-remote — though that one is auto-preserved on re-run, the env var is
+# there for the initial attachment).
 define run-admin
 	@token=$$($(DC) run --rm --entrypoint bao bao kv get -mount=kv -field=token infra/openbao/admin-token 2>/dev/null) && \
 	[ -n "$$token" ] || (echo "ERROR: could not fetch admin token from kv/infra/openbao/admin-token" && exit 1) && \
-	$(DC) run --rm -e BAO_TOKEN=$$token -e EXTRA_CIDRS=$(EXTRA_CIDRS) bao $(1)
+	$(DC) run --rm -e BAO_TOKEN=$$token -e EXTRA_CIDRS=$(EXTRA_CIDRS) -e EXTRA_POLICIES=$(EXTRA_POLICIES) bao $(1)
 endef
 
 help:
@@ -20,8 +23,8 @@ help:
 	@echo ""
 	@echo "Admin targets (auto-fetch admin token from KV):"
 	@echo "  make approle-enable                           Enable AppRole auth + create nixos-host policy (one-time)"
-	@echo "  make approle-create-role NAME=dns1 IP=10.10.15.15 [EXTRA_CIDRS=...]"
-	@echo "                                                Create/upsert a CIDR-bound role for a NixOS host"
+	@echo "  make approle-create-role NAME=dns1 IP=10.10.15.15 [EXTRA_CIDRS=...] [EXTRA_POLICIES=...]"
+	@echo "                                                Create/upsert a role. Existing token_policies are preserved on re-run."
 	@echo "  make approle-show-role NAME=dns1              Show role_id for a host"
 	@echo "  make approle-list                             List all AppRole roles"
 	@echo ""

--- a/openbao/Makefile
+++ b/openbao/Makefile
@@ -3,15 +3,16 @@ DC := docker compose --env-file ../.env
 
 .DEFAULT_GOAL := help
 
-.PHONY: help approle-enable approle-create-role approle-show-role approle-list shell
+.PHONY: help build approle-enable approle-create-role approle-show-role approle-list shell
 
 # Admin targets fetch the approle-admin token from KV (using the deploy
 # token in .env), then run the privileged command with it. The admin token
-# never touches .env or disk.
+# never touches .env or disk. EXTRA_CIDRS is passed through for create-role
+# (used when an agent needs to connect from an additional CIDR like 127.0.0.1).
 define run-admin
 	@token=$$($(DC) run --rm --entrypoint bao bao kv get -mount=kv -field=token infra/openbao/admin-token 2>/dev/null) && \
 	[ -n "$$token" ] || (echo "ERROR: could not fetch admin token from kv/infra/openbao/admin-token" && exit 1) && \
-	$(DC) run --rm -e BAO_TOKEN=$$token bao $(1)
+	$(DC) run --rm -e BAO_TOKEN=$$token -e EXTRA_CIDRS=$(EXTRA_CIDRS) bao $(1)
 endef
 
 help:
@@ -19,15 +20,20 @@ help:
 	@echo ""
 	@echo "Admin targets (auto-fetch admin token from KV):"
 	@echo "  make approle-enable                           Enable AppRole auth + create nixos-host policy (one-time)"
-	@echo "  make approle-create-role NAME=dns1 IP=10.10.15.15  Create CIDR-bound role for a NixOS host"
+	@echo "  make approle-create-role NAME=dns1 IP=10.10.15.15 [EXTRA_CIDRS=...]"
+	@echo "                                                Create/upsert a CIDR-bound role for a NixOS host"
 	@echo "  make approle-show-role NAME=dns1              Show role_id for a host"
 	@echo "  make approle-list                             List all AppRole roles"
 	@echo ""
 	@echo "General targets (use BAO_TOKEN from .env):"
+	@echo "  make build                                    Build the bao container image (jq, openssl, curl)"
 	@echo "  make shell                                    Interactive bao CLI shell"
 	@echo ""
 	@echo "Requires BAO_ADDR and BAO_TOKEN in root .env."
 	@echo "Admin targets fetch the approle-admin token from kv/infra/openbao/admin-token."
+
+build:
+	$(DC) build bao
 
 approle-enable:
 	$(call run-admin,/workspace/scripts/setup-approle.sh enable)

--- a/openbao/docker-compose.yml
+++ b/openbao/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   bao:
-    image: openbao/openbao:2.4.4
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: homelab-openbao:2.4.4
     entrypoint: /bin/sh
     working_dir: /workspace
     environment:

--- a/openbao/scripts/setup-approle.sh
+++ b/openbao/scripts/setup-approle.sh
@@ -11,13 +11,23 @@
 
 set -eu
 
-# NixOS hosts need read access to user password hashes (and future secrets)
+# NixOS hosts need read access to user password hashes and the LE wildcard
+# cert (delivered to bao2's TCP listener and to Traefik on containers2 via
+# openbao-agent). Containers2's backup secrets at kv/data/backup/* are
+# granted by additional policy attachments on that role, not by this base
+# policy.
 NIXOS_POLICY_NAME="nixos-host"
 NIXOS_POLICY='
 path "kv/data/infra/users/*" {
   capabilities = ["read"]
 }
 path "kv/metadata/infra/users/*" {
+  capabilities = ["read"]
+}
+path "kv/data/infra/certs/*" {
+  capabilities = ["read"]
+}
+path "kv/metadata/infra/certs/*" {
   capabilities = ["read"]
 }
 '
@@ -48,13 +58,24 @@ cmd_enable() {
 cmd_create_role() {
     name="${1:?Usage: create-role <name> <ip>}"
     ip="${2:?Usage: create-role <name> <ip>}"
+    # Optional: comma-separated extra CIDRs to add to the binding. Useful
+    # when the agent connects to OpenBao via loopback (bao2 itself), so the
+    # token must also be usable from 127.0.0.1/32 in addition to the host's
+    # LAN IP. Passed through env so the existing IP positional stays simple.
+    extra_cidrs="${EXTRA_CIDRS:-}"
 
-    echo "Creating AppRole '$name' bound to $ip/32..."
+    if [ -n "$extra_cidrs" ]; then
+        cidrs="${ip}/32,${extra_cidrs}"
+    else
+        cidrs="${ip}/32"
+    fi
+
+    echo "Creating/updating AppRole '$name' bound to $cidrs..."
 
     bao write "auth/approle/role/$name" \
         bind_secret_id=false \
         secret_id_bound_cidrs="" \
-        token_bound_cidrs="${ip}/32" \
+        token_bound_cidrs="$cidrs" \
         token_policies="$NIXOS_POLICY_NAME" \
         token_ttl=1h \
         token_max_ttl=4h \
@@ -63,12 +84,12 @@ cmd_create_role() {
     role_id=$(bao read -field=role_id "auth/approle/role/$name/role-id")
 
     echo ""
-    echo "Role '$name' created."
+    echo "Role '$name' written. (Upsert — role_id preserved across re-runs.)"
     echo "  role_id: $role_id"
-    echo "  bound_cidr: ${ip}/32"
+    echo "  bound_cidrs: $cidrs"
     echo "  policy: $NIXOS_POLICY_NAME"
     echo ""
-    echo "Write this role_id to the host:"
+    echo "If this is a NEW host, write the role_id to the host:"
     echo "  ssh deploy@${name} 'sudo mkdir -p /etc/openbao && echo \"$role_id\" | sudo tee /etc/openbao/role_id'"
 }
 

--- a/openbao/scripts/setup-approle.sh
+++ b/openbao/scripts/setup-approle.sh
@@ -58,11 +58,19 @@ cmd_enable() {
 cmd_create_role() {
     name="${1:?Usage: create-role <name> <ip>}"
     ip="${2:?Usage: create-role <name> <ip>}"
-    # Optional: comma-separated extra CIDRs to add to the binding. Useful
-    # when the agent connects to OpenBao via loopback (bao2 itself), so the
-    # token must also be usable from 127.0.0.1/32 in addition to the host's
-    # LAN IP. Passed through env so the existing IP positional stays simple.
+    # Optional env vars:
+    #   EXTRA_CIDRS:    comma-separated extra CIDRs to add to the binding.
+    #                   Used when the agent connects from an additional source
+    #                   IP (e.g. bao2 needs 127.0.0.1/32 because its agent
+    #                   talks to its own openbao via loopback).
+    #   EXTRA_POLICIES: comma-separated extra policies to add on top of the
+    #                   base nixos-host policy and any policies already
+    #                   attached out-of-band (e.g. containers2 has
+    #                   backup-remote attached). Existing policies are
+    #                   ALWAYS preserved on re-run — see the read-then-merge
+    #                   logic below.
     extra_cidrs="${EXTRA_CIDRS:-}"
+    extra_policies="${EXTRA_POLICIES:-}"
 
     if [ -n "$extra_cidrs" ]; then
         cidrs="${ip}/32,${extra_cidrs}"
@@ -70,13 +78,35 @@ cmd_create_role() {
         cidrs="${ip}/32"
     fi
 
-    echo "Creating/updating AppRole '$name' bound to $cidrs..."
+    # Read the role's current token_policies if the role exists, so re-running
+    # this command is non-destructive for policies attached out-of-band. Since
+    # `bao write` replaces token_policies wholesale, naively writing just
+    # NIXOS_POLICY_NAME would silently drop attachments like backup-remote.
+    existing=""
+    if existing_json=$(bao read -format=json "auth/approle/role/$name" 2>/dev/null); then
+        existing=$(echo "$existing_json" | jq -r '.data.token_policies | join(",")')
+    fi
+
+    # Merge: existing + base + extras, deduped. tr/sort/paste handles dedup
+    # without requiring jq for the merge step.
+    merged="$existing,$NIXOS_POLICY_NAME"
+    if [ -n "$extra_policies" ]; then
+        merged="$merged,$extra_policies"
+    fi
+    policies=$(echo "$merged" | tr ',' '\n' | sed '/^$/d' | sort -u | paste -sd ',')
+
+    echo "Creating/updating AppRole '$name'..."
+    echo "  bound_cidrs:    $cidrs"
+    echo "  token_policies: $policies"
+    if [ -n "$existing" ] && [ "$existing" != "$NIXOS_POLICY_NAME" ]; then
+        echo "    (preserved existing: $existing)"
+    fi
 
     bao write "auth/approle/role/$name" \
         bind_secret_id=false \
         secret_id_bound_cidrs="" \
         token_bound_cidrs="$cidrs" \
-        token_policies="$NIXOS_POLICY_NAME" \
+        token_policies="$policies" \
         token_ttl=1h \
         token_max_ttl=4h \
         token_period=1h
@@ -86,8 +116,6 @@ cmd_create_role() {
     echo ""
     echo "Role '$name' written. (Upsert — role_id preserved across re-runs.)"
     echo "  role_id: $role_id"
-    echo "  bound_cidrs: $cidrs"
-    echo "  policy: $NIXOS_POLICY_NAME"
     echo ""
     echo "If this is a NEW host, write the role_id to the host:"
     echo "  ssh deploy@${name} 'sudo mkdir -p /etc/openbao && echo \"$role_id\" | sudo tee /etc/openbao/role_id'"


### PR DESCRIPTION
Closes the LE wildcard cert auto-renewal item from #220 and addresses the bulk of #232 (the doc rewrite). After `make lego-renew && make lego-store`, bao2 and containers2 both auto-rotate the cert within ~2 minutes — no manual scp, no service restart on openbao, no traefik blip beyond ~1-2s on actual cert change.

## Architecture

`modules/openbao-agent.nix` gains per-secret `owner`/`group`/`command`/`manageDestinationDir` options, then both bao2 and containers2 declare two cert-delivery secrets that point at `kv/data/infra/certs/lan.quietlife.net`:

- **bao2** renders to `/var/lib/openbao/tls/{tls.crt,tls.key}` (`openbao:openbao`), command on the key fires `systemctl reload openbao`. SIGHUP re-reads listener TLS in place without re-sealing.
- **containers2** renders to `/opt/stacks/certs/lan.quietlife.net.{crt,key}` (`deploy:users`), command on the key fires `docker restart traefik` (Traefik doesn't watch bind-mounted cert files).

The bao2 chicken-and-egg (its agent talks TLS to the openbao whose TLS we're refreshing) is solved by pointing the agent at `https://localhost:8200` with `tlsSkipVerify = true`. Loopback-only — no MITM concern, and an expired listener cert doesn't block the agent from replacing it.

To prevent NixOS deploys from restarting openbao every time the unit definition changes, the openbao service gets `ExecReload=kill -HUP $MAINPID` and `reloadIfChanged = true`. Default NixOS behavior on unit changes is restart-on-change, which would seal openbao on every unit-touching deploy.

## OpenBao policy + tooling changes

- `nixos-host` policy gains read on `kv/data/infra/certs/*` and `kv/metadata/infra/certs/*`. Re-running `make openbao-approle-enable` upserts idempotently.
- `setup-approle.sh` create-role accepts `EXTRA_CIDRS` for hosts whose token must be usable from additional source IPs — bao2 specifically needs `127.0.0.1/32` added to its `10.10.15.16/32` binding because the agent now connects via loopback. Upsert preserves the role_id.
- New `openbao/Dockerfile` adds jq, openssl, and curl to the upstream openbao image — needed for ad-hoc cert/secret debugging from the workstation. New `make openbao-build` target.

## Verified end-to-end on 2026-04-29

Walked through pre-flight (cert in KV matched disk, policy upserted, SIGHUP reload confirmed on live openbao without seal), deploy bao2, deploy containers2, then a real Let's Encrypt renewal as the rotation test:

- KV cert rotated from `F3:71:0F:F7:B7:C6:16:BF:95:ED:1E:4F:08:7A:4C:1F:6E:31:C8:63` to `78:F3:84:56:D0:0C:04:2F:4A:89:27:90:57:91:AA:D2:2A:6B:58:8E`.
- bao2: agent picked up KV change ~2 minutes after `lego-store`, rendered cert/key, fired `systemctl reload openbao`. **openbao stayed at PID 602**, `Sealed=false`, listener serving the new cert. SIGHUP-reload working as designed.
- containers2: same timing, agent rendered + `docker restart traefik` fired, traefik back up serving new cert.

## Operational gotcha that surfaced during the walkthrough

bao2's AppRole was `token_bound_cidrs = "10.10.15.16/32"`. When the agent switched from DNS to loopback, source IP became 127.0.0.1 → token use rejected with 403 on every KV read. Fixed by extending `setup-approle.sh` to accept `EXTRA_CIDRS=127.0.0.1/32` and upserting bao2's role; role_id preserved so `/etc/openbao/role_id` didn't need re-staging.

This is documented inline in `setup-approle.sh` and called out in the agent module's localhost-loopback comment so the next person debugging a similar 403 has the breadcrumb.

## Test plan

- [x] `nix flake check --no-build` — all 5 NixOS configurations evaluate clean
- [x] Pre-flight: cert in KV matches disk on bao2 (byte-identical, same fingerprint)
- [x] Pre-flight: SIGHUP to openbao keeps PID stable, sealed=false (manual `kill -HUP` test before deploy)
- [x] Deploy bao2: openbao reloaded not restarted (PID 602 unchanged), agent active, no 403s
- [x] Deploy containers2: agent active, file ownership corrected to deploy:users, traefik restarted once for ownership fix-up
- [x] End-to-end rotation: `make lego-renew && make lego-store` → both hosts pick up new cert within 2 minutes, listeners serve new cert, openbao stays unsealed
- [x] AppRole 127.0.0.1/32 binding fix verified (agent auths cleanly post-fix)

## Out of scope

- The "first-boot chicken-and-egg" on bao2 (no cert on disk → `ConditionPathExists` blocks openbao → agent can't reach a not-running openbao) is unchanged. The migration runbook handles it with a one-shot manual cert stage. Worth a separate doc note but not a blocker.
- Auto-renewal scheduling (running `lego-renew` on a timer) is still manual. With auto-delivery in place, that's a small follow-up — could land as a NixOS systemd timer on dns1 or a workstation cron. Not in this PR.
