### PR TITLE
Rename bao2 → bao (post-migration cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The LAN is `10.10.15.0/24` under the domain `lan.quietlife.net`. A couple of ext
 | **pve1** | 10.10.15.18 | Proxmox VE hypervisor — runs all local VMs |
 | **fw1** | 10.10.15.1 | OpenBSD firewall/router — pf, DHCP, Unbound (recursive DNS), WireGuard VPN |
 | **dns1** | 10.10.15.15 | NSD authoritative DNS for `lan.quietlife.net` (NixOS) |
-| **bao2** | 10.10.15.16 | Secrets management (OpenBao, a HashiCorp Vault fork; NixOS) |
+| **bao** | 10.10.15.16 | Secrets management (OpenBao, a HashiCorp Vault fork; NixOS) |
 | **containers2** | 10.10.15.11 | Docker host (NixOS) — [Traefik, Jellyfin, arr stack, Paperless](docs/services.md), GPU passthrough |
 | **portanas** | 10.10.15.4 | Synology NAS — NFS storage backing media, documents, and [backups](backup/README.md) |
 | **felix** | 45.56.113.70 | Linode VPS |

--- a/ansible/roles/openbsd_firewall/templates/dhcpd.conf.j2
+++ b/ansible/roles/openbsd_firewall/templates/dhcpd.conf.j2
@@ -3,7 +3,7 @@
 #
 # Static reservations below must stay in sync with DNS A records in
 # hosts/dns1/configuration.nix (NSD zone data).
-# VMs (dns1, containers, bao2) get their IPs from cloud-init (tofu),
+# VMs (dns1, containers, bao) get their IPs from cloud-init (tofu),
 # not DHCP, so they don't appear here.
 
 option  domain-name "quietlife.net";

--- a/docs/tls-certificates.md
+++ b/docs/tls-certificates.md
@@ -7,7 +7,7 @@ Wildcard TLS certificate management for `*.lan.quietlife.net` using Let's Encryp
 ```
 lego/ (ACME client)        OpenBao                  Deploy
 ───────────────────        ───────                  ──────
-Let's Encrypt cert    →  Stored at            →  bao2 (own listener):
+Let's Encrypt cert    →  Stored at            →  bao (own listener):
 via DNS-01 challenge     kv/infra/certs/          openbao-agent → /var/lib/openbao/tls/
 (Cloudflare API)         lan.quietlife.net         + systemctl reload openbao (SIGHUP)
 
@@ -20,7 +20,7 @@ via DNS-01 challenge     kv/infra/certs/          openbao-agent → /var/lib/ope
                                                    (proxmox_certs role)
 ```
 
-bao2 and containers2 both run `homelab.openbao-agent` (see `modules/openbao-agent.nix`) with templates that deliver the cert/key from KV to disk and fire a post-rotation hook. Agent polls KV roughly every 1-2 minutes, so a `make lego-store` is automatically picked up without manual deploy. bao2 talks to its own openbao via loopback with TLS verification disabled — that breaks the chicken-and-egg where bao2's listener TLS depends on the very cert the agent is responsible for refreshing.
+bao and containers2 both run `homelab.openbao-agent` (see `modules/openbao-agent.nix`) with templates that deliver the cert/key from KV to disk and fire a post-rotation hook. Agent polls KV roughly every 1-2 minutes, so a `make lego-store` is automatically picked up without manual deploy. bao talks to its own openbao via loopback with TLS verification disabled — that breaks the chicken-and-egg where bao's listener TLS depends on the very cert the agent is responsible for refreshing.
 
 ## Certificate lifecycle
 
@@ -44,7 +44,7 @@ Cloudflare API credentials (API token, zone ID) are fetched from OpenBao at depl
 
 After `make lego-store` writes the new cert to `kv/infra/certs/lan.quietlife.net`, deployment to consumers happens automatically except for Proxmox:
 
-- **bao2** (its own TCP listener): `homelab.openbao-agent` template renders the cert/key from KV to `/var/lib/openbao/tls/{tls.crt,tls.key}` (owned `openbao:openbao`) and fires `systemctl reload openbao` — SIGHUP makes openbao re-read TLS in place without re-sealing. Picked up within ~2 minutes of `lego-store`.
+- **bao** (its own TCP listener): `homelab.openbao-agent` template renders the cert/key from KV to `/var/lib/openbao/tls/{tls.crt,tls.key}` (owned `openbao:openbao`) and fires `systemctl reload openbao` — SIGHUP makes openbao re-read TLS in place without re-sealing. Picked up within ~2 minutes of `lego-store`.
 - **Traefik** (containers2): same agent pattern, renders to `/opt/stacks/certs/lan.quietlife.net.{crt,key}` (owned `deploy:users`) and fires `docker restart traefik` (~1-2s blip on rotation).
 - **Proxmox** (pve1): `make ansible-proxmox` — still Ansible-driven for the Proxmox web UI cert via the `proxmox_certs` role.
 
@@ -57,12 +57,12 @@ If the cert has already expired, OpenBao (which serves its own TLS on port 8200)
 make lego-renew
 
 # 2. Push the new cert to OpenBao with TLS verification disabled. The
-#    workstation can't validate bao2's expired cert, so verify-skip is
+#    workstation can't validate bao's expired cert, so verify-skip is
 #    needed for this one push.
 BAO_SKIP_VERIFY=true make lego-store
 
-# 3. bao2 and containers2 auto-rotate within ~2 minutes — no further
-#    action needed. bao2's openbao-agent connects via loopback with TLS
+# 3. bao and containers2 auto-rotate within ~2 minutes — no further
+#    action needed. bao's openbao-agent connects via loopback with TLS
 #    verification disabled (intentional, see modules/openbao-agent.nix
 #    and hosts/openbao/configuration.nix), so an expired listener cert
 #    doesn't block the agent from refreshing it.

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
         ];
       };
 
-      nixosConfigurations.bao2 = nixpkgs.lib.nixosSystem {
+      nixosConfigurations.bao = nixpkgs.lib.nixosSystem {
         inherit system;
         modules = [
           "${nixpkgs}/nixos/modules/virtualisation/proxmox-image.nix"

--- a/hosts/containers2/configuration.nix
+++ b/hosts/containers2/configuration.nix
@@ -4,7 +4,7 @@
   networking.hostName = "containers2";
 
   # Prevent cloud-init from overriding the hostname after rebuild
-  # (same workaround as dns1/bao2)
+  # (same workaround as dns1/bao)
   environment.etc."cloud/cloud.cfg.d/99-preserve-hostname.cfg".text = ''
     preserve_hostname: true
   '';

--- a/hosts/dns1/configuration.nix
+++ b/hosts/dns1/configuration.nix
@@ -31,7 +31,7 @@
           $TTL 300
 
           @       IN  SOA dns1.lan.quietlife.net. hostmaster.lan.quietlife.net. (
-                      2026042902  ; serial (YYYYMMDDNN)
+                      2026042903  ; serial (YYYYMMDDNN)
                       3600        ; refresh
                       600         ; retry
                       604800      ; expire
@@ -50,7 +50,6 @@
           portapttyeth    IN  A       10.10.15.6
           dns1            IN  A       10.10.15.15
           bao             IN  A       10.10.15.16
-          bao2            IN  A       10.10.15.16
           containers      IN  A       10.10.15.12
           containers2     IN  A       10.10.15.11
           nintendoswitch  IN  A       10.10.15.13
@@ -79,7 +78,7 @@
           $TTL 300
 
           @       IN  SOA dns1.lan.quietlife.net. hostmaster.lan.quietlife.net. (
-                      2026042902  ; serial
+                      2026042903  ; serial
                       3600        ; refresh
                       600         ; retry
                       604800      ; expire
@@ -100,7 +99,7 @@
           12      IN  PTR     containers.lan.quietlife.net.
           13      IN  PTR     nintendoswitch.lan.quietlife.net.
           15      IN  PTR     dns1.lan.quietlife.net.
-          16      IN  PTR     bao2.lan.quietlife.net.
+          16      IN  PTR     bao.lan.quietlife.net.
           18      IN  PTR     pve1.lan.quietlife.net.
           20      IN  PTR     lattepanda.lan.quietlife.net.
           115     IN  PTR     remarkable.lan.quietlife.net.

--- a/hosts/openbao/configuration.nix
+++ b/hosts/openbao/configuration.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 {
-  networking.hostName = "bao2";
+  networking.hostName = "bao";
 
   # Prevent cloud-init from overriding the hostname after rebuild
   # (same workaround as dns1)
@@ -44,7 +44,7 @@
 
     storage "raft" {
       path    = "/var/lib/openbao/data"
-      node_id = "bao2"
+      node_id = "bao"
     }
 
     api_addr     = "https://bao.lan.quietlife.net:8200"
@@ -53,8 +53,8 @@
 
   # --- OpenBao agent for secrets ---
   # Connects via loopback with TLS verification disabled to break the
-  # chicken-and-egg: bao2's TCP listener uses the very TLS cert this agent is
-  # responsible for refreshing. Loopback-only means there's no MITM concern,
+  # chicken-and-egg: bao's own TCP listener uses the very TLS cert this agent
+  # is responsible for refreshing. Loopback-only means there's no MITM concern,
   # and skipping verification means an expired cert can still be replaced.
   # The agent waits and retries if the local server is sealed.
   homelab.openbao-agent = {
@@ -69,7 +69,7 @@
         destination = "/etc/secrets/cwage-password-hash";
       };
 
-      # LE wildcard cert delivery for bao2's own TCP listener. The cert dir
+      # LE wildcard cert delivery for bao's own TCP listener. The cert dir
       # is created and owned by the openbao server module above, so we tell
       # the agent module not to redeclare it.
       tls-cert = {
@@ -146,7 +146,7 @@
   # staged manually at /etc/openbao/backup-token (mode 0600 root:root).
   # Mint with:
   #   bao token create -policy=backup -no-default-policy -orphan \
-  #     -period=8760h -display-name="bao2-backup" -field=token \
+  #     -period=8760h -display-name="bao-backup" -field=token \
   #     | sudo tee /etc/openbao/backup-token >/dev/null
   #   sudo chmod 0600 /etc/openbao/backup-token
 

--- a/lego/README.md
+++ b/lego/README.md
@@ -29,7 +29,7 @@ make fetch-creds      # test OpenBao credential retrieval (masked output)
 make renew            # get new cert from Let's Encrypt
 make store            # push to OpenBao
 # Then deploy:
-#   Traefik (containers2) and bao2: auto-deployed via openbao-agent within
+#   Traefik (containers2) and bao: auto-deployed via openbao-agent within
 #     ~2 minutes of `make store`. No further action needed.
 #   Proxmox web UI:        make ansible-proxmox
 ```

--- a/modules/openbao-agent.nix
+++ b/modules/openbao-agent.nix
@@ -147,7 +147,7 @@ in
               directory (0750 root:root) via systemd.tmpfiles. Set to false
               when the directory is already declared elsewhere in the host
               config with the ownership/perms the consumer needs (e.g.
-              /var/lib/openbao/tls owned by openbao:openbao on bao2). The
+              /var/lib/openbao/tls owned by openbao:openbao on bao). The
               agent's ReadWritePaths still includes the parent dir either
               way, so the agent can write into it.
             '';

--- a/openbao/Makefile
+++ b/openbao/Makefile
@@ -8,7 +8,7 @@ DC := docker compose --env-file ../.env
 # Admin targets fetch the approle-admin token from KV (using the deploy
 # token in .env), then run the privileged command with it. The admin token
 # never touches .env or disk. EXTRA_CIDRS / EXTRA_POLICIES are passed through
-# for create-role to support hosts that need extra source IPs (e.g. bao2's
+# for create-role to support hosts that need extra source IPs (e.g. bao's
 # 127.0.0.1/32) or extra policies on top of nixos-host (e.g. containers2's
 # backup-remote — though that one is auto-preserved on re-run, the env var is
 # there for the initial attachment).

--- a/openbao/scripts/setup-approle.sh
+++ b/openbao/scripts/setup-approle.sh
@@ -12,7 +12,7 @@
 set -eu
 
 # NixOS hosts need read access to user password hashes and the LE wildcard
-# cert (delivered to bao2's TCP listener and to Traefik on containers2 via
+# cert (delivered to bao's TCP listener and to Traefik on containers2 via
 # openbao-agent). Containers2's backup secrets at kv/data/backup/* are
 # granted by additional policy attachments on that role, not by this base
 # policy.
@@ -61,7 +61,7 @@ cmd_create_role() {
     # Optional env vars:
     #   EXTRA_CIDRS:    comma-separated extra CIDRs to add to the binding.
     #                   Used when the agent connects from an additional source
-    #                   IP (e.g. bao2 needs 127.0.0.1/32 because its agent
+    #                   IP (e.g. bao needs 127.0.0.1/32 because its agent
     #                   talks to its own openbao via loopback).
     #   EXTRA_POLICIES: comma-separated extra policies to add on top of the
     #                   base nixos-host policy and any policies already

--- a/tofu/AGENTS.md
+++ b/tofu/AGENTS.md
@@ -16,7 +16,7 @@ OpenTofu configuration for provisioning VMs on a Proxmox VE host (pve1, 10.10.15
 - `main.tf` — Provider config (bpg/proxmoxve)
 - `variables.tf` — All input variables with descriptions and defaults
 - `images.tf` — Debian cloud image download for Proxmox
-- Individual VM files: `dns1.tf`, `bao2.tf`, `containers2.tf`
+- Individual VM files: `dns1.tf`, `bao.tf`, `containers2.tf`
 - `outputs.tf` — Output values
 
 ## Credentials

--- a/tofu/README.md
+++ b/tofu/README.md
@@ -7,7 +7,7 @@ OpenTofu (Terraform fork) configuration for provisioning VMs on Proxmox VE. All 
 | Resource | VM ID | Description |
 |----------|-------|-------------|
 | `dns1` | 150 | NSD authoritative DNS for `lan.quietlife.net` (NixOS) |
-| `bao2` | 151 | Secrets management server (NixOS) |
+| `bao` | 151 | Secrets management server (NixOS) |
 | `containers2` | 152 | Docker host with GTX 1050 Ti GPU passthrough (NixOS) |
 
 VMs clone from either the Debian stable cloud image (`images.tf`) or the NixOS template (`pm_nixos_template_id`) and use cloud-init for bootstrap (SSH key, static IP, hostname).
@@ -53,7 +53,7 @@ State is stored on the NAS via NFS (mounted at `TOFU_STATE_PATH` from `.env`). T
 ├── variables.tf      Input variables with defaults
 ├── images.tf         Debian cloud image download
 ├── dns1.tf           dns1 VM (NixOS)
-├── bao2.tf           bao2 VM (secrets management, NixOS)
+├── bao.tf            bao VM (secrets management, NixOS)
 ├── containers2.tf    containers2 VM (Docker host + GPU, NixOS)
 ├── hardware-mappings.tf  Cluster-level hardware mappings (USB passthrough, etc.)
 ├── outputs.tf        Output values

--- a/tofu/bao.tf
+++ b/tofu/bao.tf
@@ -1,10 +1,7 @@
-# bao2: NixOS-based replacement for the openbao VM (#218 / #132).
-# Stood up alongside the existing Debian openbao VM (10.10.15.11). Once data
-# is migrated and clients are repointed, the old VM and tofu/openbao.tf are
-# decommissioned, and DNS for bao.lan.quietlife.net flips to this host.
+# bao: OpenBao secrets management server (NixOS).
 
-resource "proxmox_virtual_environment_vm" "bao2" {
-  name      = "bao2"
+resource "proxmox_virtual_environment_vm" "bao" {
+  name      = "bao"
   node_name = var.pm_node_name
   vm_id     = 151
 

--- a/tofu/outputs.tf
+++ b/tofu/outputs.tf
@@ -10,7 +10,7 @@ output "dns1_ip" {
   value       = "10.10.15.15"
 }
 
-output "bao2_ip" {
-  description = "IP address of bao2 VM (NixOS replacement for openbao)"
+output "bao_ip" {
+  description = "IP address of bao VM (NixOS)"
   value       = "10.10.15.16"
 }


### PR DESCRIPTION
Closes #236.

Cosmetic rename of the OpenBao VM from its migration-era name `bao2` to `bao`. Same VM (151), same IP (10.10.15.16), same data — just drops the `2` suffix that's been historical cruft since the legacy Debian openbao VM was decommissioned.

## What changed

- `hosts/openbao/configuration.nix` — hostname + raft `node_id` → `bao`
- `flake.nix` — `nixosConfigurations.bao`
- `tofu/{bao2.tf → bao.tf}` — file + resource label + `name` attr
- `tofu/outputs.tf` — `bao_ip`
- `hosts/dns1/configuration.nix` — drop `bao2 IN A`, flip PTR for `.16`, bump SOA serial
- Docs/comments swept across `README.md`, `docs/tls-certificates.md`, `lego/README.md`, `tofu/{AGENTS,README}.md`, `modules/openbao-agent.nix`, `openbao/{Makefile,scripts/setup-approle.sh}`, `dhcpd.conf.j2`, `hosts/containers2/configuration.nix`

`git grep bao2` returns nothing after this PR.

The AppRole role name in OpenBao stays as `bao2` — the host config only references the role_id (UUID), so it's operational state, not codebase cruft, and renaming the role would invalidate the baked-in role_id.

## Deploy is already live

Per the procedure documented in #236, the deploy was driven from this branch before merge:

1. `tofu state mv proxmox_virtual_environment_vm.bao2 → .bao`
2. `tofu apply` — VM renamed in Proxmox UI (in-place, no destroy)
3. Snapshot/restore dance to apply the new `node_id`:
   - Fresh ad-hoc snapshot via `systemctl start openbao-backup.service`
   - Stop openbao + wipe `/var/lib/openbao/data/*`
   - `make nix-deploy-host HOST=bao TARGET=10.10.15.16`
   - Init throwaway, login, `bao operator raft snapshot restore -force`
   - Unseal with original key
4. `make nix-deploy-host HOST=dns1 TARGET=10.10.15.15` for the zone update

## Verified post-deploy

- `bao status`: Sealed=false, HA active, `cluster_id 050a2ca5-...` matches pre-rename
- `dig bao.lan.quietlife.net @10.10.15.15` → 10.10.15.16
- `dig bao2.lan.quietlife.net @10.10.15.15` → NXDOMAIN
- `dig -x 10.10.15.16 @10.10.15.15` → `bao.lan.quietlife.net.`
- `make tofu-plan` clean (no diff)
- dns1 + containers2 openbao-agents stopped erroring after the 23:27:42 unseal
- `git grep bao2` returns nothing

## Quirk noted along the way

NixOS doesn't manage `/etc/hostname` on these cloud-init-provisioned VMs — `networking.hostName` only sets the kernel hostname during boot, but the `/etc/hostname` file is whatever cloud-init wrote at first provisioning, and `preserve_hostname: true` keeps cloud-init from rewriting it later. Manual fix on bao: `echo bao > /etc/hostname && hostname bao`. Same caveat applies to #237 (containers2 → containers) and any future hostname rename.

## Test plan

- [x] `git grep bao2` returns nothing
- [x] `bao.lan.quietlife.net` resolves to 10.10.15.16
- [x] `bao2.lan.quietlife.net` returns NXDOMAIN
- [x] PTR for 10.10.15.16 returns `bao.lan.quietlife.net.`
- [x] VM in Proxmox UI is named `bao`
- [x] OpenBao server up, unsealed, serving secrets
- [x] dns1 + containers2 openbao-agents authenticate without errors
- [x] `make tofu-plan` is clean
