### PR TITLE
Deliver remaining stack secrets via openbao-agent

### DIFF
--- a/hosts/containers/configuration.nix
+++ b/hosts/containers/configuration.nix
@@ -153,12 +153,15 @@
   # /opt/stacks holds the docker-compose.yml + supporting files.
   # deploy user's primary group is "users" (NixOS default for isNormalUser).
   # Static stack config (compose, traefik dyn config) is symlinked from the
-  # nix store. Secrets (.env, basicauth, ssh deploy key) and TLS certs remain
-  # mutable in /opt/stacks until they migrate to openbao-agent / lego.
+  # nix store. Stack secrets (.env, traefik basicauth, staticomment ssh key)
+  # and the wildcard TLS cert are rendered by openbao-agent into the dirs
+  # below.
   systemd.tmpfiles.rules = [
-    "d /opt/stacks       0755 deploy users -"
-    "d /opt/stacks/certs 0700 deploy users -"
-    "z /opt/stacks/certs 0700 deploy users -"
+    "d /opt/stacks                  0755 deploy users -"
+    "d /opt/stacks/certs            0700 deploy users -"
+    "z /opt/stacks/certs            0700 deploy users -"
+    "d /opt/stacks/staticomment-ssh 0700 deploy users -"
+    "z /opt/stacks/staticomment-ssh 0700 deploy users -"
     "L+ /opt/stacks/docker-compose.yml - - - - ${./stacks/docker-compose.yml}"
     "L+ /opt/stacks/traefik-tls.yml    - - - - ${./stacks/traefik-tls.yml}"
   ];
@@ -169,10 +172,9 @@
   ];
 
   # --- OpenBao agent for secrets ---
-  # Currently delivers the cwage password hash and the B2 backup credentials.
-  # Stack secrets (.env, traefik basicauth, staticomment ssh deploy key) and
-  # lego-managed TLS certs are still mutable in /opt/stacks/ and are slated
-  # to move into the agent in a follow-up.
+  # Delivers: cwage password hash, B2 backup credentials, wildcard TLS cert
+  # for Traefik, and the three stack secrets (compose .env, traefik
+  # basicauth, staticomment SSH deploy key).
   # roleId is per-host and CIDR-bound to 10.10.15.11.
   homelab.openbao-agent = {
     enable = true;
@@ -203,6 +205,54 @@
       # password2 (salt) intentionally omitted — this rclone crypt remote uses
       # the default salt, not a custom one. Templating a non-existent field
       # would write the literal string "<no value>" to disk and break rclone.
+
+      # --- Stack secrets ---
+      # /opt/stacks is 0755 deploy:users (declared above); render each file
+      # with explicit owner/group + manageDestinationDir = false so the
+      # agent doesn't try to redeclare the dir. Each secret is stored in
+      # OpenBao as a single `content` field whose value is the entire
+      # file body (same approach as the cert delivery below).
+
+      # docker-compose .env (CLOUDFLARE_TUNNEL_TOKEN, STATICOMMENT_*).
+      # Compose only re-reads .env at compose-up time, so on rotation we
+      # `compose up -d` to recreate any container whose env changed.
+      stacks-env = {
+        path = "kv/data/stacks/containers/env";
+        field = "content";
+        destination = "/opt/stacks/.env";
+        owner = "deploy";
+        group = "users";
+        permissions = "0600";
+        manageDestinationDir = false;
+        command = "${pkgs.bash}/bin/bash -c 'cd /opt/stacks && ${pkgs.docker}/bin/docker compose up -d'";
+      };
+
+      # Traefik basicauth (htpasswd) for the dashboard middleware. Bind-
+      # mounted into the container; Traefik reads it at start, so a
+      # restart is required on rotation.
+      stacks-traefik-basicauth = {
+        path = "kv/data/stacks/containers/basicauth";
+        field = "content";
+        destination = "/opt/stacks/traefik-basicauth";
+        owner = "deploy";
+        group = "users";
+        permissions = "0600";
+        manageDestinationDir = false;
+        command = "${pkgs.docker}/bin/docker restart traefik";
+      };
+
+      # staticomment SSH deploy key. The dir at /opt/stacks/staticomment-ssh
+      # is 0700 deploy:users (declared above).
+      stacks-staticomment-ssh-key = {
+        path = "kv/data/stacks/containers/staticomment-ssh-key";
+        field = "content";
+        destination = "/opt/stacks/staticomment-ssh/id_ed25519";
+        owner = "deploy";
+        group = "users";
+        permissions = "0600";
+        manageDestinationDir = false;
+        command = "${pkgs.docker}/bin/docker restart staticomment";
+      };
 
       # LE wildcard cert delivery for Traefik. The dir at /opt/stacks/certs
       # is 0700 deploy:users (declared above), so we set owner/group on the

--- a/hosts/containers/configuration.nix
+++ b/hosts/containers/configuration.nix
@@ -158,6 +158,7 @@
   # below.
   systemd.tmpfiles.rules = [
     "d /opt/stacks                  0755 deploy users -"
+    "z /opt/stacks                  0755 deploy users -"
     "d /opt/stacks/certs            0700 deploy users -"
     "z /opt/stacks/certs            0700 deploy users -"
     "d /opt/stacks/staticomment-ssh 0700 deploy users -"
@@ -284,6 +285,13 @@
       };
     };
   };
+
+  # The agent's stack-secret post-render hooks invoke docker (compose up,
+  # restart). Ordering after docker.service ensures those commands don't
+  # race the daemon on a cold boot — without this, a fresh boot can render
+  # secrets before docker is up, the command fails silently, and the
+  # consumer container never gets restarted until the next rotation.
+  systemd.services.openbao-agent.after = [ "docker.service" ];
 
   # --- ntfy.sh notifications ---
   # OnFailure/OnSuccess hooks on the backup units pull last 20 journal lines


### PR DESCRIPTION
Move the last three mutable stack secrets on the containers host
(`/opt/stacks/.env`, `traefik-basicauth`, `staticomment-ssh/id_ed25519`)
into openbao-agent delivery, matching the pattern established for the
wildcard TLS cert in #234.

A fresh containers VM rebuilt from the flake now comes up with a working
stack — no manual file placement required.

## Changes

- `hosts/containers/configuration.nix`
  - Three new `homelab.openbao-agent.secrets` entries (`stacks-env`,
    `stacks-traefik-basicauth`, `stacks-staticomment-ssh-key`), each
    rendering a single `content` field from `kv/stacks/containers/*`
    to its existing on-disk path (mode 0600 deploy:users) with a
    post-rotation hook (`compose up -d` for env, `docker restart` for
    traefik / staticomment).
  - New tmpfiles entry pre-creating `/opt/stacks/staticomment-ssh/`
    as 0700 deploy:users so the agent can render `id_ed25519` inside it
    with `manageDestinationDir = false`.
  - Comment cleanup in the host config to reflect the new state.

## Out-of-band setup (already done)

- Three new KV entries created at `kv/stacks/containers/{env,basicauth,
  staticomment-ssh-key}`, each with a single `content` field holding
  the whole file body.
- New `containers-host` policy granting `read` on
  `kv/{data,metadata}/stacks/containers/*`, attached to the
  `containers2` AppRole alongside the existing `nixos-host` and
  `backup-remote` policies.

## Test plan

- [x] `make nix-deploy-host HOST=containers TARGET=containers.lan.quietlife.net`
      builds and activates without error.
- [x] `openbao-agent` re-renders all 8 secrets after the deploy; journal
      shows three new `(runner) rendered` lines for the stack secrets.
- [x] Post-render commands fire: `docker compose up -d` (no-op since
      env content unchanged), `docker restart traefik`, `docker restart
      staticomment`.
- [x] All three rendered files end up `deploy:users 600` (clearing the
      stale `deploy:UNKNOWN` GID left over from the Debian-era deploy
      user's primary group).
- [x] Traefik dashboard reachable + basicauth still gates it.
- [x] staticomment back to `Up` state, `git pull --rebase` succeeds in
      logs (`Already up to date.`), `listening on :8080`.
      *(Note: SSH key was rotated as part of this rollout — terminal
      copy-paste of the original key mangled the base64 body. New
      ed25519 deploy key installed on `cwage/quietlife.net` with write
      access; old deploy key removed.)*
- [x] Other compose services (`jellyfin`, `sabnzbd`, `radarr`, `sonarr`,
      `paperless`, `paperless-redis`, `cloudflared`) untouched by the
      rollout.
