### PR TITLE
containers: auto-recover Jellyfin GPU container after docker restart

### DIFF
--- a/hosts/containers/configuration.nix
+++ b/hosts/containers/configuration.nix
@@ -147,6 +147,38 @@
   # CDI-based GPU access for containers (also used by the runtime above).
   hardware.nvidia-container-toolkit.enable = true;
 
+  # Work around a Docker startup race that breaks GPU containers after every
+  # reboot / docker.service restart. dockerd restores `restart: unless-stopped`
+  # containers during daemon startup *before* its CDI registry is populated, so
+  # the jellyfin container (devices: nvidia.com/gpu=all) comes up with
+  # "could not select device driver cdi", exits 128, and is never retried -
+  # which 404s Jellyfin until a manual `docker start`. The CDI spec file is
+  # already present in /run/cdi at that point, so spec-generator ordering does
+  # not help; the fix is to (re)start the container once dockerd is fully up.
+  #
+  # partOf docker.service => this re-runs whenever docker restarts (e.g. on a
+  # nixos activation that bounces docker). The guard skips the start when the
+  # container is already running, so a normal activation won't kill live
+  # playback.
+  systemd.services.jellyfin-gpu-start = {
+    description = "Start the Jellyfin GPU container once Docker's CDI registry is ready";
+    after = [ "docker.service" ];
+    requires = [ "docker.service" ];
+    partOf = [ "docker.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = pkgs.writeShellScript "start-jellyfin-gpu" ''
+        set -eu
+        running=$(${pkgs.docker}/bin/docker inspect -f '{{.State.Running}}' jellyfin 2>/dev/null || echo missing)
+        if [ "$running" != "true" ]; then
+          ${pkgs.docker}/bin/docker start jellyfin
+        fi
+      '';
+    };
+  };
+
   users.users.deploy.extraGroups = [ "docker" ];
   users.users.cwage.extraGroups = [ "docker" ];
 


### PR DESCRIPTION
## Problem

After the containers Proxmox node rebooted, `jellyfin.lan.quietlife.net` returned 404. Root cause: Docker 27 restores `restart: unless-stopped` containers during daemon startup **before its CDI registry is populated**. The jellyfin container (`devices: nvidia.com/gpu=all`) therefore comes up with `could not select device driver "cdi"`, exits 128, and is never retried. Traefik then has no jellyfin backend → 404, until a manual `docker start jellyfin`.

The GPU passthrough itself is healthy (`nvidia-smi` works inside the VM) and the CDI spec file is already present in `/run/cdi` at startup — so generating/ordering the spec earlier does **not** fix it. The tell is that a manual `docker start` once the daemon is fully up always succeeds.

This reproduces on every reboot **and** on every `docker.service` restart (e.g. a nixos activation), not just the original outage.

## Fix

Add a `jellyfin-gpu-start` systemd oneshot that starts the container once `docker.service` is fully up (CDI registry ready):

- `after`/`requires` `docker.service` — runs after dockerd is initialized.
- `partOf` `docker.service` — re-runs whenever docker is bounced (deploys, reboots).
- Guards on the container not already running, so a routine activation won't kill live playback.

## Test Plan

- Deployed to `containers` via `make nix-deploy-host HOST=containers`.
- Observed the deploy's docker bounce drop jellyfin to `Exited (128)` (the race), then `jellyfin-gpu-start` recovered it automatically:
  - `systemctl is-active jellyfin-gpu-start` → `active`, `Result=success`, `ExecMainStatus=0`
  - journal shows it ran `docker start jellyfin`
  - jellyfin container `Up`, GPU visible inside container (`GTX 1050 Ti`)
  - `https://jellyfin.lan.quietlife.net/` → HTTP 302 (healthy)
- Cold-reboot path uses the identical unit ordering; full validation requires a VM reboot (not yet performed).
