### PR TITLE
fw1: add macbookpro WireGuard peer (10.10.16.5)

### DIFF
--- a/ansible/inventories/host_vars/fw1.yml
+++ b/ansible/inventories/host_vars/fw1.yml
@@ -14,3 +14,7 @@ wireguard_peers:
     public_key: "N/gPS5QD6K4cKgt7iCYbpepXGmU9JZrp6+RJ0Mfm3D4="
     allowed_ips: "10.10.16.4/32"
     persistent_keepalive: 0
+  - name: macbookpro
+    public_key: "+Wt0dW9Zg1z8i4G2wJ0BUZcMXAKJnRVZ8WMERLWXdH8="
+    allowed_ips: "10.10.16.5/32"
+    persistent_keepalive: 0


### PR DESCRIPTION
Add a new WireGuard peer (`macbookpro`) to the fw1 server config.

Changes
- Add peer `macbookpro` to `wireguard_peers` in `ansible/inventories/host_vars/fw1.yml`
  - public_key: `+Wt0dW9Zg1z8i4G2wJ0BUZcMXAKJnRVZ8WMERLWXdH8=`
  - allowed_ips: `10.10.16.5/32`
  - persistent_keepalive: 0

Test Plan
- Deployed via the firewall playbook to fw1.
- Confirmed the peer is present in `/etc/hostname.wg0` and live in `ifconfig wg0` (wgpeer + wgaip 10.10.16.5/32).
- Connectivity from the new peer verified working.
