### PR TITLE
scripts: cap Bluray/Remux 1080p sizes in Radarr/Sonarr

### DIFF
--- a/scripts/arr-quality-caps.sh
+++ b/scripts/arr-quality-caps.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Cap Bluray/Remux 1080p quality definitions in Radarr & Sonarr so they stop
+# grabbing 13-16GB Blu-ray encodes that are overkill for a streaming/Chromecast
+# setup (and that choke on transcode / wifi).
+#
+# WHY THIS EXISTS: the default *arr quality definitions cap WEB/HDTV tiers
+# (~100-130 MB/min) but leave Bluray and Remux UNCAPPED (maxSize=null). That's
+# why huge Bluray-1080p releases (~115-130 MB/min, 13-16GB/movie) get grabbed.
+# This sets a sane MB/min ceiling on just those tiers. Idempotent.
+#
+# Pulls each app's API key from /config/config.xml inside the running container
+# over SSH -- no need to copy it from the UI. SSHes as your user (in the docker
+# group on containers), not deploy.
+#
+# Companion to scripts/radarr-english-only.sh / scripts/sonarr-english-only.sh
+# (those handle language + disallowing Remux; this handles file size).
+#
+# Usage:
+#   scripts/arr-quality-caps.sh
+#
+# Overrides:
+#   SSH_HOST=cwage@containers.lan.quietlife.net   (default)
+#   RADARR_URL=https://radarr.lan.quietlife.net   (default)
+#   SONARR_URL=https://sonarr.lan.quietlife.net   (default)
+#   MAX_MBMIN=70    # hard ceiling, MB per minute  (~9GB for a 2h movie)
+#   PREF_MBMIN=50   # preferred target, MB per minute
+#
+# Requires: ssh, curl, jq
+
+set -euo pipefail
+
+SSH_HOST="${SSH_HOST:-cwage@containers.lan.quietlife.net}"
+RADARR_URL="${RADARR_URL:-https://radarr.lan.quietlife.net}"
+SONARR_URL="${SONARR_URL:-https://sonarr.lan.quietlife.net}"
+MAX_MBMIN="${MAX_MBMIN:-70}"
+PREF_MBMIN="${PREF_MBMIN:-50}"
+
+# Matches Bluray-1080p, "Bluray-1080p Remux", Remux-1080p, etc. -- the tiers
+# that ship uncapped. WEB/HDTV tiers are left alone (already capped sanely).
+QUALITY_REGEX='(Bluray|Remux).*1080p|1080p.*(Bluray|Remux)'
+
+cap_app() {
+  local name="$1" url="$2" container="$3"
+  echo "== ${name} =="
+
+  local key
+  key=$(ssh -o BatchMode=yes "$SSH_HOST" "docker exec ${container} cat /config/config.xml" \
+    | sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p')
+  [[ -n "$key" ]] || { echo "  ERROR: could not read ${container} API key"; return 1; }
+
+  local defs
+  defs=$(curl -fsS -H "X-Api-Key: $key" "${url}/api/v3/qualitydefinition")
+
+  # Emit one compact JSON object per matching definition. Iterate by id so
+  # quality names containing spaces (e.g. "Bluray-1080p Remux") are safe.
+  local matched=0
+  while IFS= read -r def; do
+    [[ -n "$def" ]] || continue
+    matched=1
+    local qn id body
+    qn=$(jq -r '.quality.name' <<<"$def")
+    id=$(jq -r '.id' <<<"$def")
+    body=$(jq -c --argjson mx "$MAX_MBMIN" --argjson pf "$PREF_MBMIN" \
+      '.maxSize = $mx | .preferredSize = (if .minSize > $pf then .minSize else $pf end)' <<<"$def")
+    curl -fsS -X PUT -H "X-Api-Key: $key" -H "Content-Type: application/json" \
+      "${url}/api/v3/qualitydefinition/${id}" -d "$body" >/dev/null \
+      && echo "  ${qn} -> pref=${PREF_MBMIN} max=${MAX_MBMIN} MB/min"
+  done < <(jq -c --arg re "$QUALITY_REGEX" '.[] | select(.quality.name | test($re))' <<<"$defs")
+
+  [[ "$matched" -eq 1 ]] || echo "  (no matching quality definitions found)"
+}
+
+cap_app Radarr "$RADARR_URL" radarr
+cap_app Sonarr "$SONARR_URL" sonarr
+
+echo ""
+echo "Done. Caps apply to future grabs and upgrades; already-downloaded"
+echo "oversized files are left in place (delete + re-search to replace them)."

--- a/scripts/radarr-english-only.sh
+++ b/scripts/radarr-english-only.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Push a "Language: Not English" custom format into Radarr and wire it
+# into the HD-1080p quality profile (score -10000, minFormatScore=0), so
+# non-English releases are rejected at grab time. Also disallows
+# Remux-1080p in that profile so Radarr prefers compact Bluray-1080p
+# encodes over 30GB+ lossless remuxes (overkill for a 720p-capped
+# Chromecast). Idempotent.
+#
+# Radarr counterpart of scripts/sonarr-english-only.sh.
+#
+# Pulls Radarr's API key from /config/config.xml inside the running
+# container over SSH -- no need to copy it from the UI. SSHes as your
+# user (in the docker group on containers), not deploy.
+#
+# Usage:
+#   scripts/radarr-english-only.sh
+#
+# Overrides:
+#   SSH_HOST=cwage@containers.lan.quietlife.net  (default)
+#   RADARR_URL=https://radarr.lan.quietlife.net  (default)
+#   QP_NAME=HD-1080p                             (default)
+#
+# Requires: ssh, curl, jq
+
+set -euo pipefail
+
+SSH_HOST="${SSH_HOST:-cwage@containers.lan.quietlife.net}"
+RADARR_URL="${RADARR_URL:-https://radarr.lan.quietlife.net}"
+QP_NAME="${QP_NAME:-HD-1080p}"
+CF_NAME="Language: Not English"
+CF_SCORE=-10000
+
+echo "Fetching Radarr API key from $SSH_HOST ..."
+RADARR_API_KEY=$(ssh -o BatchMode=yes "$SSH_HOST" 'docker exec radarr cat /config/config.xml' \
+  | sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p')
+[[ -n "$RADARR_API_KEY" ]] || { echo "ERROR: could not extract API key from config.xml"; exit 1; }
+echo "  got key (${#RADARR_API_KEY} chars)"
+
+call() {
+  curl -fsS -H "X-Api-Key: $RADARR_API_KEY" -H "Content-Type: application/json" "$@"
+}
+
+echo "Checking $RADARR_URL ..."
+call "$RADARR_URL/api/v3/system/status" >/dev/null
+echo "  API key OK"
+
+existing=$(call "$RADARR_URL/api/v3/customformat" \
+  | jq -r --arg n "$CF_NAME" '.[] | select(.name == $n) | .id // empty')
+
+if [[ -z "$existing" ]]; then
+  cf_body='{
+    "name": "Language: Not English",
+    "includeCustomFormatWhenRenaming": false,
+    "specifications": [
+      {
+        "name": "Not English Language",
+        "implementation": "LanguageSpecification",
+        "negate": true,
+        "required": false,
+        "fields": [ { "name": "value", "value": 1 } ]
+      }
+    ]
+  }'
+  echo "Creating custom format '$CF_NAME' ..."
+  cf_id=$(call -X POST "$RADARR_URL/api/v3/customformat" -d "$cf_body" | jq -r '.id')
+  echo "  created (id=$cf_id)"
+else
+  cf_id="$existing"
+  echo "Custom format '$CF_NAME' already exists (id=$cf_id)"
+fi
+
+echo "Updating quality profile '$QP_NAME' ..."
+qp=$(call "$RADARR_URL/api/v3/qualityprofile" \
+  | jq --arg n "$QP_NAME" '.[] | select(.name == $n)')
+if [[ -z "$qp" ]]; then
+  echo "ERROR: no quality profile named '$QP_NAME' in Radarr"
+  echo "Available profiles:"
+  call "$RADARR_URL/api/v3/qualityprofile" | jq -r '.[].name | "  - " + .'
+  exit 1
+fi
+qp_id=$(jq -r '.id' <<<"$qp")
+
+new_qp=$(jq \
+  --argjson cf_id "$cf_id" \
+  --arg cf_name "$CF_NAME" \
+  --argjson score "$CF_SCORE" '
+    .minFormatScore = 0
+    | .items = (.items | map(
+        if .quality.name == "Remux-1080p" then .allowed = false else . end
+      ))
+    | .formatItems = (
+        [.formatItems[] | select(.format != $cf_id)]
+        + [{format: $cf_id, name: $cf_name, score: $score}]
+      )
+  ' <<<"$qp")
+
+call -X PUT "$RADARR_URL/api/v3/qualityprofile/$qp_id" -d "$new_qp" >/dev/null
+echo "  minFormatScore=0; '$CF_NAME' score=$CF_SCORE; Remux-1080p disallowed"
+echo ""
+echo "Done."
+echo "Next: set the Add-Movie default quality profile to '$QP_NAME' in the"
+echo "Radarr UI (Add Movie -> pick HD-1080p; Radarr remembers it). New movies"
+echo "will then default to 1080p and reject non-English releases."

--- a/scripts/sonarr-english-only.sh
+++ b/scripts/sonarr-english-only.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Push a "Language: Not English" custom format into Sonarr and wire it
+# into the HD-1080p quality profile (score -10000, minFormatScore=0), so
+# non-English releases are rejected at grab time. Idempotent.
+#
+# Pulls Sonarr's API key from /config/config.xml inside the running
+# container over SSH — no need to copy it from the UI. SSHes as your
+# user (in the docker group on containers), not deploy.
+#
+# Usage:
+#   scripts/sonarr-english-only.sh
+#
+# Overrides:
+#   SSH_HOST=cwage@containers.lan.quietlife.net  (default)
+#   SONARR_URL=https://sonarr.lan.quietlife.net  (default)
+#   QP_NAME=HD-1080p                             (default)
+#
+# Requires: ssh, curl, jq
+
+set -euo pipefail
+
+SSH_HOST="${SSH_HOST:-cwage@containers.lan.quietlife.net}"
+SONARR_URL="${SONARR_URL:-https://sonarr.lan.quietlife.net}"
+QP_NAME="${QP_NAME:-HD-1080p}"
+CF_NAME="Language: Not English"
+CF_SCORE=-10000
+
+echo "Fetching Sonarr API key from $SSH_HOST ..."
+SONARR_API_KEY=$(ssh -o BatchMode=yes "$SSH_HOST" 'docker exec sonarr cat /config/config.xml' \
+  | sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p')
+[[ -n "$SONARR_API_KEY" ]] || { echo "ERROR: could not extract API key from config.xml"; exit 1; }
+echo "  got key (${#SONARR_API_KEY} chars)"
+
+call() {
+  curl -fsS -H "X-Api-Key: $SONARR_API_KEY" -H "Content-Type: application/json" "$@"
+}
+
+echo "Checking $SONARR_URL ..."
+call "$SONARR_URL/api/v3/system/status" >/dev/null
+echo "  API key OK"
+
+existing=$(call "$SONARR_URL/api/v3/customformat" \
+  | jq -r --arg n "$CF_NAME" '.[] | select(.name == $n) | .id // empty')
+
+if [[ -z "$existing" ]]; then
+  cf_body='{
+    "name": "Language: Not English",
+    "includeCustomFormatWhenRenaming": false,
+    "specifications": [
+      {
+        "name": "Not English Language",
+        "implementation": "LanguageSpecification",
+        "negate": true,
+        "required": false,
+        "fields": [ { "name": "value", "value": 1 } ]
+      }
+    ]
+  }'
+  echo "Creating custom format '$CF_NAME' ..."
+  cf_id=$(call -X POST "$SONARR_URL/api/v3/customformat" -d "$cf_body" | jq -r '.id')
+  echo "  created (id=$cf_id)"
+else
+  cf_id="$existing"
+  echo "Custom format '$CF_NAME' already exists (id=$cf_id)"
+fi
+
+echo "Updating quality profile '$QP_NAME' ..."
+qp=$(call "$SONARR_URL/api/v3/qualityprofile" \
+  | jq --arg n "$QP_NAME" '.[] | select(.name == $n)')
+if [[ -z "$qp" ]]; then
+  echo "ERROR: no quality profile named '$QP_NAME' in Sonarr"
+  echo "Available profiles:"
+  call "$SONARR_URL/api/v3/qualityprofile" | jq -r '.[].name | "  - " + .'
+  exit 1
+fi
+qp_id=$(jq -r '.id' <<<"$qp")
+
+new_qp=$(jq \
+  --argjson cf_id "$cf_id" \
+  --arg cf_name "$CF_NAME" \
+  --argjson score "$CF_SCORE" '
+    .minFormatScore = 0
+    | .formatItems = (
+        [.formatItems[] | select(.format != $cf_id)]
+        + [{format: $cf_id, name: $cf_name, score: $score}]
+      )
+  ' <<<"$qp")
+
+call -X PUT "$SONARR_URL/api/v3/qualityprofile/$qp_id" -d "$new_qp" >/dev/null
+echo "  minFormatScore=0; '$CF_NAME' score=$CF_SCORE"
+echo ""
+echo "Done."
+echo "Next: delete the bad Daredevil files in Sonarr, then click 'Search Monitored'."


### PR DESCRIPTION
Stops Radarr/Sonarr from grabbing bloated 13–16 GB Blu-ray rips that are overkill for streaming/casting and cause transcode + wifi stutter.

## Root cause
The default *arr quality definitions cap the WEB/HDTV tiers (~100–130 MB/min) but leave **Bluray and Remux uncapped** (`maxSize=null`). So the apps grab whatever is biggest — Blu-ray encodes at ~115–130 MB/min (13–16 GB/movie). The previous "no-remux" tweak didn't help because the offenders were plain `Bluray-1080p` encodes, not remuxes.

## Changes
- **`scripts/arr-quality-caps.sh`** (new): caps `Bluray-1080p` + `Bluray-1080p Remux` / `Remux-1080p` to `pref=50 / max=70` MB/min (~9 GB max for a 2-hour movie) in both Radarr and Sonarr. Idempotent, pulls API keys from the running containers over SSH, tunable via `MAX_MBMIN`/`PREF_MBMIN`. Already applied live.
- **`scripts/radarr-english-only.sh` / `scripts/sonarr-english-only.sh`**: previously-uncommitted companions — add a "Language: Not English" custom format wired into the HD-1080p profile to reject non-English at grab time; Radarr variant also disallows Remux-1080p.

## Notes
- Quality definitions are global, so the size caps apply regardless of which quality profile a title uses.
- Caps affect future grabs/upgrades; already-downloaded oversized files are left in place (delete + re-search to replace).
- No secrets embedded; API keys are fetched from the containers at runtime.

## Test Plan
- `bash -n` clean on all three scripts.
- Live-verified Radarr + Sonarr now report `Bluray-1080p` and Remux tiers at `pref=50 max=70` (were `max=null`).
