### PR TITLE
Bump staticomment to 0.3.0 and pass Turnstile secret

### DIFF
--- a/hosts/containers/stacks/docker-compose.yml
+++ b/hosts/containers/stacks/docker-compose.yml
@@ -154,13 +154,14 @@ services:
       - proxy
 
   staticomment:
-    image: ghcr.io/cwage/staticomment:0.2.0
+    image: ghcr.io/cwage/staticomment:0.3.0
     container_name: staticomment
     restart: unless-stopped
     environment:
       - STATICOMMENT_GIT_REPO=${STATICOMMENT_GIT_REPO}
       - STATICOMMENT_BRANCH=${STATICOMMENT_BRANCH:-main}
       - STATICOMMENT_ALLOWED_ORIGINS=${STATICOMMENT_ALLOWED_ORIGINS}
+      - STATICOMMENT_TURNSTILE_SECRET=${STATICOMMENT_TURNSTILE_SECRET:-}
       - STATICOMMENT_SSH_KEY_PATH=/app/.ssh/id_ed25519
     volumes:
       - ./staticomment-ssh:/app/.ssh


### PR DESCRIPTION
Bumps the staticomment container to `0.3.0` and passes through the new Turnstile secret.

## Changes
- `hosts/containers/stacks/docker-compose.yml`:
  - Image `ghcr.io/cwage/staticomment:0.2.0` → `:0.3.0`.
  - Add `STATICOMMENT_TURNSTILE_SECRET=${STATICOMMENT_TURNSTILE_SECRET:-}` to the env list.

staticomment 0.3.0 adds opt-in Cloudflare Turnstile server-side verification — the durable defense against bots POSTing directly to the comment endpoint. The widget lives on the blog (cwage/quietlife.net#49); this wires the matching secret into the server.

## Safe by default
The `:-` default means that until the secret is present in the stack `.env`, the var resolves to empty and staticomment leaves Turnstile **disabled** — identical to today's behavior. No compose warning either (verified with `docker compose config`). So merging + deploying this alone changes nothing observable; Turnstile only turns on once the secret exists.

## Required manual step (OpenBao) to actually enable Turnstile
The stack `.env` is rendered by openbao-agent from `kv/stacks/containers/env` (field `content`, the whole file body). Add this line to that secret's content:

```
STATICOMMENT_TURNSTILE_SECRET=<turnstile-secret-key>
```

On render, the agent's post-render hook runs `docker compose up -d`, recreating staticomment with the new image + secret.

## Deploy
1. `nixos-rebuild` the `containers` host so `/opt/stacks/docker-compose.yml` points at the `:0.3.0` version.
2. Update the OpenBao `env` secret as above (this triggers `compose up -d`, which pulls `:0.3.0` and recreates the container with the secret).

## Verify after deploy
- `docker exec staticomment wget -qO- https://challenges.cloudflare.com/turnstile/v0/siteverify` returns a response (egress works — staticomment fails closed if it can't reach Cloudflare).
- `docker logs staticomment` shows `turnstile: enabled (server-side token verification)`.
