### PR TITLE
Add CryptPad to containers stack

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -14,11 +14,22 @@ All self-hosted services run as Docker containers on the **containers** host (`1
 | **Paperless-ngx** | `paperless-ngx/paperless-ngx` | `https://paperless.lan.quietlife.net` | Document management |
 | **Paperless Redis** | `redis` | — | Backend for Paperless-ngx |
 | **staticomment** | `ghcr.io/cwage/staticomment` | `https://staticomment.lan.quietlife.net` | Comment endpoint for `quietlife.net` |
-| **Cloudflared** | `cloudflare/cloudflared` | — | Cloudflare Tunnel for external access (Jellyfin) |
+| **CryptPad** | `cryptpad/cryptpad` | `https://pad.quietlife.net` (public, via tunnel) | End-to-end encrypted collaborative markdown/docs |
+| **Cloudflared** | `cloudflare/cloudflared` | — | Cloudflare Tunnel for external access (Jellyfin, CryptPad) |
 
 ## External access
 
-Jellyfin is exposed externally via a Cloudflare Tunnel (`cloudflared` container). The tunnel token is stored in OpenBao at `kv/infra/cloudflare/tunnel`. Tunnel ingress routes are configured in the Cloudflare Zero Trust dashboard.
+Jellyfin and CryptPad are exposed externally via a Cloudflare Tunnel (`cloudflared` container). The tunnel token is stored in OpenBao at `kv/infra/cloudflare/tunnel`. Tunnel ingress routes are configured in the Cloudflare Zero Trust dashboard.
+
+CryptPad is **public-only** (no internal Traefik route) and end-to-end encrypted — documents are shared by link, with the decryption key carried in the URL fragment, so no per-user accounts are required to collaborate. It needs **two** hostnames: the main origin `pad.quietlife.net` and a sandbox origin `pad-sandbox.quietlife.net` (security isolation). cloudflared reaches the container over the `proxy` network on **two ports** — HTTP on `:3000` and the realtime WebSocket (`/cryptpad_websocket`) on `:3003` — so the tunnel has three public-hostname routes:
+
+| Public hostname | Path | Service |
+|---|---|---|
+| `pad.quietlife.net` | `cryptpad_websocket` | `http://cryptpad:3003` |
+| `pad.quietlife.net` | (catch-all) | `http://cryptpad:3000` |
+| `pad-sandbox.quietlife.net` | (catch-all) | `http://cryptpad:3000` |
+
+The websocket-path route must be ordered **above** the catch-all. CryptPad needs no OpenBao secret (no DB/SMTP; `adminKeys` is a public key). OnlyOffice is not installed — the markdown and rich-text apps don't require it.
 
 ## How it fits together
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -25,7 +25,7 @@ CryptPad is **public-only** (no internal Traefik route) and end-to-end encrypted
 
 | Public hostname | Path | Service |
 |---|---|---|
-| `pad.quietlife.net` | `cryptpad_websocket` | `http://cryptpad:3003` |
+| `pad.quietlife.net` | `/cryptpad_websocket` | `http://cryptpad:3003` |
 | `pad.quietlife.net` | (catch-all) | `http://cryptpad:3000` |
 | `pad-sandbox.quietlife.net` | (catch-all) | `http://cryptpad:3000` |
 

--- a/hosts/containers/configuration.nix
+++ b/hosts/containers/configuration.nix
@@ -371,6 +371,14 @@
         { name = "radarr";          mount = "/config"; }
         { name = "sonarr";          mount = "/config"; }
         { name = "paperless-redis"; mount = "/data"; }
+        # CryptPad stores data across several dirs; back up the four that hold
+        # real state (documents/channels, pins+metadata, uploaded blobs, and
+        # account login blocks). The job stops/starts the container per entry,
+        # so cryptpad briefly flaps a few times during the nightly snapshot.
+        { name = "cryptpad";        mount = "/cryptpad/datastore"; }
+        { name = "cryptpad";        mount = "/cryptpad/data"; }
+        { name = "cryptpad";        mount = "/cryptpad/blob"; }
+        { name = "cryptpad";        mount = "/cryptpad/block"; }
       ];
     };
 

--- a/hosts/containers/stacks/docker-compose.yml
+++ b/hosts/containers/stacks/docker-compose.yml
@@ -197,10 +197,13 @@ services:
       - cryptpad_blob:/cryptpad/blob
       - cryptpad_block:/cryptpad/block
       - cryptpad_customize:/cryptpad/customize
+    # CryptPad recommends a generous fd limit; 65536 is ample for this small
+    # instance and well under any host's hard max (avoids host-dependent
+    # `compose up` failures from over-requesting).
     ulimits:
       nofile:
-        soft: 1000000
-        hard: 1000000
+        soft: 65536
+        hard: 65536
     networks:
       - proxy
 

--- a/hosts/containers/stacks/docker-compose.yml
+++ b/hosts/containers/stacks/docker-compose.yml
@@ -174,6 +174,36 @@ services:
     networks:
       - proxy
 
+  # Public-only, exposed via the Cloudflare Tunnel at pad.quietlife.net.
+  # CryptPad is end-to-end encrypted (the decryption key lives in the URL
+  # fragment) and requires a SECOND "sandbox" origin for security isolation,
+  # hence pad-sandbox.quietlife.net. cloudflared reaches it over the proxy
+  # network: HTTP on :3000 and the realtime WebSocket on :3003
+  # (/cryptpad_websocket) — both tunnel routes are configured in the
+  # Cloudflare Zero Trust dashboard. OnlyOffice is intentionally not
+  # installed; the markdown (Code) and rich-text apps don't need it.
+  cryptpad:
+    image: cryptpad/cryptpad:version-2026.5.1
+    container_name: cryptpad
+    restart: unless-stopped
+    environment:
+      - CPAD_MAIN_DOMAIN=https://pad.quietlife.net
+      - CPAD_SANDBOX_DOMAIN=https://pad-sandbox.quietlife.net
+      - CPAD_CONF=/cryptpad/config/config.js
+    volumes:
+      - cryptpad_config:/cryptpad/config
+      - cryptpad_datastore:/cryptpad/datastore
+      - cryptpad_data:/cryptpad/data
+      - cryptpad_blob:/cryptpad/blob
+      - cryptpad_block:/cryptpad/block
+      - cryptpad_customize:/cryptpad/customize
+    ulimits:
+      nofile:
+        soft: 1000000
+        hard: 1000000
+    networks:
+      - proxy
+
   cloudflared:
     image: cloudflare/cloudflared:2026.1.2
     container_name: cloudflared
@@ -185,6 +215,7 @@ services:
       - proxy
     depends_on:
       - jellyfin
+      - cryptpad
     profiles:
       - tunnel
 
@@ -195,6 +226,12 @@ volumes:
   radarr_config:
   sonarr_config:
   paperless_redis:
+  cryptpad_config:
+  cryptpad_datastore:
+  cryptpad_data:
+  cryptpad_blob:
+  cryptpad_block:
+  cryptpad_customize:
 
 networks:
   proxy:


### PR DESCRIPTION
Adds [CryptPad](https://cryptpad.org) to the containers stack — a self-hosted, end-to-end encrypted collaborative editor — exposed publicly at `pad.quietlife.net` via the Cloudflare Tunnel. Use case: share-by-link markdown collaboration (e.g. grocery lists, notes) with another person, no accounts or email required.

## How it works
- **E2E encrypted, share-by-link**: the decryption key lives in the URL fragment, never sent to the server. Share a doc's **Edit** link and the other person edits live in their browser — no login. Use the **Code** app for markdown (raw editor + live preview).
- **Public-only** (no internal Traefik route); `cloudflared` reaches the container over the `proxy` network.
- Requires **two** origins: main `pad.quietlife.net` and sandbox `pad-sandbox.quietlife.net` (CryptPad security isolation), plus a separate WebSocket port.

## Changes
- `docker-compose.yml`: `cryptpad` service (`cryptpad/cryptpad:version-2026.5.1`), six named volumes, added to `cloudflared` `depends_on`. OnlyOffice intentionally not installed.
- `configuration.nix`: back up the four data dirs (`datastore`, `data`, `blob`, `block`) via the nightly `configs` job.
- `docs/services.md`: inventory row + tunnel route table.

## Tunnel routes (configured in Cloudflare Zero Trust dashboard)
| Hostname | Path | Service |
|---|---|---|
| `pad.quietlife.net` | `cryptpad_websocket` | `http://cryptpad:3003` |
| `pad.quietlife.net` | (catch-all) | `http://cryptpad:3000` |
| `pad-sandbox.quietlife.net` | (catch-all) | `http://cryptpad:3000` |

The websocket-path route must be ordered above the catch-all.

## Notes
- **No OpenBao secret needed** (no DB/SMTP; `adminKeys` is a public key).

## Test plan / verification (deployed to containers, 10.10.15.11)
- Container healthy; listening on `:3000` and `:3003`.
- `https://pad.quietlife.net/` → HTTP 200; `https://pad-sandbox.quietlife.net/` → HTTP 200.
- `wss://pad.quietlife.net/cryptpad_websocket` → `101 Switching Protocols` (real-time collab confirmed end-to-end through the tunnel).
- First-run instance/admin setup via the `/install/#...` token (no email).
