### PR TITLE
Manage switch1 (MikroTik CRS310) via OpenTofu

### DIFF
--- a/ansible/roles/openbsd_firewall/templates/dhcpd.conf.j2
+++ b/ansible/roles/openbsd_firewall/templates/dhcpd.conf.j2
@@ -32,6 +32,10 @@ host pve {                                          # Proxmox VE hypervisor
   fixed-address 10.10.15.18;
 }
 
+# switch1 (MikroTik CRS310) has a static IP set on-device at 10.10.15.7 — it is
+# not a DHCP client, so there is no host stanza here. .7 is in the infra range
+# (outside the .100-.254 pool). See the NSD zone for its A/PTR records.
+
 # --- Workstations ---
 host portaplotz {                                   # desktop
   hardware ethernet a0:36:bc:ad:d2:74;

--- a/hosts/dns1/configuration.nix
+++ b/hosts/dns1/configuration.nix
@@ -31,7 +31,7 @@
           $TTL 300
 
           @       IN  SOA dns1.lan.quietlife.net. hostmaster.lan.quietlife.net. (
-                      2026042904  ; serial (YYYYMMDDNN)
+                      2026063000  ; serial (YYYYMMDDNN)
                       3600        ; refresh
                       600         ; retry
                       604800      ; expire
@@ -44,6 +44,7 @@
           ; A records — infrastructure
           fw1             IN  A       10.10.15.1
           wap             IN  A       10.10.15.2
+          switch1         IN  A       10.10.15.7
           portaplotz      IN  A       10.10.15.3
           portanas        IN  A       10.10.15.4
           portaptty       IN  A       10.10.15.5
@@ -77,7 +78,7 @@
           $TTL 300
 
           @       IN  SOA dns1.lan.quietlife.net. hostmaster.lan.quietlife.net. (
-                      2026042904  ; serial
+                      2026063000  ; serial
                       3600        ; refresh
                       600         ; retry
                       604800      ; expire
@@ -95,6 +96,7 @@
           4       IN  PTR     portanas.lan.quietlife.net.
           5       IN  PTR     portaptty.lan.quietlife.net.
           6       IN  PTR     portapttyeth.lan.quietlife.net.
+          7       IN  PTR     switch1.lan.quietlife.net.
           13      IN  PTR     nintendoswitch.lan.quietlife.net.
           15      IN  PTR     dns1.lan.quietlife.net.
           16      IN  PTR     bao.lan.quietlife.net.

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -18,6 +18,10 @@ terraform {
       source  = "hashicorp/vault"
       version = "~> 4.0"
     }
+    routeros = {
+      source  = "terraform-routeros/routeros"
+      version = "~> 1.0"
+    }
   }
 }
 

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -45,3 +45,11 @@ provider "proxmox" {
     agent = true
   }
 }
+
+# switch1 (MikroTik CRS310) REST API — creds from OpenBao (data source in switch.tf)
+provider "routeros" {
+  hosturl  = "https://${var.switch_mgmt_ip}"
+  username = data.vault_kv_secret_v2.switch1.data["username"]
+  password = data.vault_kv_secret_v2.switch1.data["password"]
+  insecure = true # self-signed cert on the switch mgmt interface
+}

--- a/tofu/switch.tf
+++ b/tofu/switch.tf
@@ -1,0 +1,46 @@
+# switch1 — MikroTik CRS310-8G+2S+IN (RouterOS v7)
+#
+# Basic scaffolding for managing the switch via the terraform-routeros provider.
+# This is intentionally minimal: it wires up the provider + credentials and
+# manages identity only. Bridge / VLAN / port config comes in a later phase
+# (see the abandoned PoC on the switch-vlan-sketch branch for the shape of it).
+#
+# PREREQUISITES before this can `apply` (none of which exist yet):
+#   1. Switch booted on RouterOS, reachable at var.switch_mgmt_ip (10.10.15.7).
+#   2. REST API reachable — enable the www-ssl service with a certificate on the
+#      switch (/ip service + /certificate), or plain www for http.
+#   3. Credentials stored in OpenBao at kv/infra/switch1 (username/password).
+#      Create that secret yourself; never commit switch creds.
+#
+# The routeros provider is declared in main.tf required_providers.
+
+variable "switch_mgmt_ip" {
+  description = "Management IP of switch1 (CRS310) on the infra LAN"
+  type        = string
+  default     = "10.10.15.7"
+}
+
+data "vault_kv_secret_v2" "switch1" {
+  mount = "kv"
+  name  = "infra/switch1"
+}
+
+provider "routeros" {
+  hosturl  = "https://${var.switch_mgmt_ip}"
+  username = data.vault_kv_secret_v2.switch1.data["username"]
+  password = data.vault_kv_secret_v2.switch1.data["password"]
+  insecure = true # self-signed cert on the switch mgmt interface
+}
+
+# First managed resource — sets the device hostname. Proves the provider /
+# REST API path works end to end before we layer on bridge + VLAN config.
+resource "routeros_system_identity" "switch1" {
+  name = "switch1"
+}
+
+# --- Deferred to a later phase (kept out on purpose) ---
+# routeros_interface_bridge        — the L2 bridge
+# routeros_interface_bridge_port   — per-port PVIDs
+# routeros_interface_bridge_vlan   — the VLAN table / isolation
+# Management IP itself is set statically on the switch (10.10.15.7), not here,
+# to avoid locking ourselves out on apply.

--- a/tofu/switch.tf
+++ b/tofu/switch.tf
@@ -1,35 +1,21 @@
 # switch1 — MikroTik CRS310-8G+2S+IN (RouterOS v7)
 #
-# Basic scaffolding for managing the switch via the terraform-routeros provider.
-# This is intentionally minimal: it wires up the provider + credentials and
-# manages identity only. Bridge / VLAN / port config comes in a later phase
-# (see the abandoned PoC on the switch-vlan-sketch branch for the shape of it).
+# Manages the switch via the terraform-routeros provider. Intentionally minimal:
+# system identity only. Bridge / VLAN / port config comes in a later phase (see
+# the abandoned PoC on the switch-vlan-sketch branch for the shape of it).
 #
-# PREREQUISITES before this can `apply` (none of which exist yet):
+# For `apply` to reach the switch, the following must hold:
 #   1. Switch booted on RouterOS, reachable at var.switch_mgmt_ip (10.10.15.7).
-#   2. REST API reachable — enable the www-ssl service with a certificate on the
+#   2. REST API reachable — the www-ssl service enabled with a certificate on the
 #      switch (/ip service + /certificate), or plain www for http.
 #   3. Credentials stored in OpenBao at kv/infra/switch1 (username/password).
-#      Create that secret yourself; never commit switch creds.
+#      Never commit switch creds.
 #
-# The routeros provider is declared in main.tf required_providers.
-
-variable "switch_mgmt_ip" {
-  description = "Management IP of switch1 (CRS310) on the infra LAN"
-  type        = string
-  default     = "10.10.15.7"
-}
+# The routeros provider block lives in main.tf; var.switch_mgmt_ip in variables.tf.
 
 data "vault_kv_secret_v2" "switch1" {
   mount = "kv"
   name  = "infra/switch1"
-}
-
-provider "routeros" {
-  hosturl  = "https://${var.switch_mgmt_ip}"
-  username = data.vault_kv_secret_v2.switch1.data["username"]
-  password = data.vault_kv_secret_v2.switch1.data["password"]
-  insecure = true # self-signed cert on the switch mgmt interface
 }
 
 # First managed resource — sets the device hostname. Proves the provider /

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -43,3 +43,9 @@ variable "pm_nixos_template_id" {
   type        = number
   default     = 9001 # nixos-template
 }
+
+variable "switch_mgmt_ip" {
+  description = "Management IP of switch1 (CRS310) on the infra LAN"
+  type        = string
+  default     = "10.10.15.7"
+}


### PR DESCRIPTION
Bring the new MikroTik CRS310 (`switch1`, `10.10.15.7`) under OpenTofu management as a pure L2 switch. The firewall keeps DHCP and dns1 keeps DNS — this device just switches. VLAN/isolation is intentionally deferred to a follow-up.

## Changes
- **`tofu/switch.tf`** (new): `terraform-routeros` provider wiring + `routeros_system_identity`. Connects over the REST API (HTTPS, self-signed cert) and reads credentials from OpenBao at `kv/infra/switch1`. Bridge/VLAN/port config is deliberately left out (a later phase).
- **`tofu/main.tf`**: declare the `terraform-routeros/routeros` provider.
- **`dhcpd.conf.j2`**: document `switch1`'s static IP. No `host` stanza — it's statically configured on-device, not a DHCP client, and `.7` is in the infra range (outside the `.100-.254` pool).
- **`hosts/dns1/configuration.nix`**: add `switch1` `A` + `PTR` records; bump both zone serials to `2026063000`.

## Test Plan
- `make tofu-plan` → clean `1 to add, 0 to change, 0 to destroy` (just `routeros_system_identity.switch1`).
- `make tofu-apply` → applied; `curl -k -u tofu:... https://10.10.15.7/rest/system/identity` returns `{"name":"switch1"}`.
- After `make nix-deploy-host HOST=dns1 TARGET=10.10.15.15`:
  - `dig +short switch1.lan.quietlife.net @10.10.15.15` → `10.10.15.7`
  - `dig +short -x 10.10.15.7 @10.10.15.15` → `switch1.lan.quietlife.net.`

## Notes / follow-ups (not in this PR)
- On-device hardening done out-of-band (one-time, not Terraform-enforceable): removed default DHCP server, `allow-remote-requests=no`, disabled `telnet`/`ftp`/`api`/`api-ssl`.
- VLAN/bridge config with RSTP + loop-protect + edge-port invariants is the next phase.
- Unrelated: `pve1` is on `8.8.8.8` DNS (stale dhcpcd lease) and can't resolve `*.lan.quietlife.net` — to be fixed separately.
